### PR TITLE
Add parameters kwarg to setup_reservoir_model

### DIFF
--- a/src/utils.jl
+++ b/src/utils.jl
@@ -29,6 +29,7 @@ function setup_reservoir_model(reservoir::DataDomain, system;
     reservoir_context = nothing,
     general_ad = false,
     backend = :csc,
+    parameters = Dict{Symbol, Any}(),
     kwarg...
     )
     # List of models (order matters)
@@ -55,7 +56,7 @@ function setup_reservoir_model(reservoir::DataDomain, system;
     # Put it all together as multimodel
     model = reservoir_multimodel(models)
     # Insert domain here.
-    parameters = setup_parameters(model)
+    parameters = setup_parameters(model, parameters...)
     return (model, parameters)
 end
 

--- a/test/multimodel.jl
+++ b/test/multimodel.jl
@@ -92,7 +92,10 @@ function test_perforation_mask()
     sys = ImmiscibleSystem(phases, reference_densities = rhoS)
     c = [1e-6/bar, 1e-4/bar]
     ρ = ConstantCompressibilityDensities(p_ref = 1*bar, density_ref = rhoS, compressibility = c)
-    model, parameters = setup_reservoir_model(domain, sys, wells = [P])
+    visLS = 1e-4
+    visGS = 1e-3
+    parameters = Dict(:Reservoir=>Dict(:PhaseViscosities=>[visLS, visGS]))
+    model, parameters = setup_reservoir_model(domain, sys, wells = [P], parameters=parameters)
     replace_variables!(model, PhaseMassDensities = ρ)
     ## Set up initial state
     state0 = setup_reservoir_state(model, Pressure = 150*bar, Saturations = [1.0, 0.0])


### PR DESCRIPTION
This PR lets the caller of `setup_reservoir_model` pass initial parameter values to `setup_parameters` through the kwarg `parameters`.