### PR TITLE
remove dependency of internal fields of `eos::AbstractEOS`

### DIFF
--- a/src/input_simulation/mrst_input.jl
+++ b/src/input_simulation/mrst_input.jl
@@ -885,9 +885,9 @@ function setup_case_from_mrst(casename; wells = :ms,
         if isa(ctrl, InjectorControl)
             factor = 1.01
             if is_comp
+                mw = MultiComponentFlash.molar_masses(model.system.equation_of_state)
                 ci = copy(vec(wdata["components"]))
-                props = model.system.equation_of_state.mixture.properties
-                ci = map((x, c) -> max(c.mw*x, 1e-10), ci, props)
+                ci = map((x, mwi) -> max(mwi*x, 1e-10), ci, mw)
                 ci = normalize(ci, 1)
             else
                 ci = vec(wdata["compi"])
@@ -1141,8 +1141,8 @@ function mrst_well_ctrl(model, wdata, is_comp, rhoS)
         elseif is_injector
             if is_comp
                 ci = copy(vec(wdata["components"]))
-                props = model.system.equation_of_state.mixture.properties
-                ci = map((x, c) -> max(c.mw*x, 1e-10), ci, props)
+                mw = MultiComponentFlash.molar_masses(model.system.equation_of_state)
+                ci = map((x, mwi) -> max(mwi*x, 1e-10), ci, mw)
                 ct = copy(ci)
                 normalize!(ct, 1)
                 if nph == 3

--- a/src/multicomponent/multicomponent.jl
+++ b/src/multicomponent/multicomponent.jl
@@ -91,7 +91,7 @@ function convergence_criterion(model::SimulationModel{<:Any, S}, storage, eq::Co
     sv = get_sat(v)
     vol = as_value(state.FluidVolume)
 
-    w = map(x -> x.mw, sys.equation_of_state.mixture.properties)
+    w = MultiComponentFlash.molar_masses(sys.equation_of_state)
     e = compositional_criterion(state, dt, active, r, nc, w, sl, liquid_density, sv, vapor_density, sw, water_density, vol)
     names = model.system.components
     R = (

--- a/src/multicomponent/variables/flash.jl
+++ b/src/multicomponent/variables/flash.jl
@@ -185,7 +185,8 @@ end
 function get_compressibility_factor(forces, eos, P, T, Z, phase = :unknown)
     ∂cond = (p = P, T = T, z = Z)
     force_coefficients!(forces, eos, ∂cond)
-    return mixture_compressibility_factor(eos, ∂cond, forces, phase)
+    scalars = force_scalars(eos, ∂cond, forces)
+    return mixture_compressibility_factor(eos, ∂cond, forces, scalars, phase)
 end
 
 @inline function single_phase_update!(P, T, Z, x, y, forces, eos, c)

--- a/src/multicomponent/variables/flash.jl
+++ b/src/multicomponent/variables/flash.jl
@@ -194,7 +194,7 @@ end
     Z_V = Z_L
     @. x = Z
     @. y = Z
-    V = single_phase_label(eos.mixture, c)
+    V = single_phase_label(eos, c)
     if V > 0.5
         phase_state = MultiComponentFlash.single_phase_v
     else

--- a/src/multicomponent/variables/flash.jl
+++ b/src/multicomponent/variables/flash.jl
@@ -182,10 +182,10 @@ function update_flash_result(S, m, eos, K, x, y, z, forces, P, T, Z, Sw = 0.0)
     return out
 end
 
-function get_compressibility_factor(forces, eos, P, T, Z)
+function get_compressibility_factor(forces, eos, P, T, Z, phase = :unknown)
     ∂cond = (p = P, T = T, z = Z)
     force_coefficients!(forces, eos, ∂cond)
-    return mixture_compressibility_factor(eos, ∂cond, forces)
+    return mixture_compressibility_factor(eos, ∂cond, forces, phase)
 end
 
 @inline function single_phase_update!(P, T, Z, x, y, forces, eos, c)
@@ -222,8 +222,8 @@ two_phase_pre!(S, P, T, Z, x, y, V, eos, c) = V
     @. x = liquid_mole_fraction(Z, K, vapor_frac)
     @. y = vapor_mole_fraction(x, K)
     V = two_phase_pre!(S, P, T, Z, x, y, vapor_frac, eos, c)
-    Z_L = get_compressibility_factor(forces, eos, P, T, x)
-    Z_V = get_compressibility_factor(forces, eos, P, T, y)
+    Z_L = get_compressibility_factor(forces, eos, P, T, x, :liquid)
+    Z_V = get_compressibility_factor(forces, eos, P, T, y, :vapor)
     phase_state = MultiComponentFlash.two_phase_lv
 
     return (Z_L::AD, Z_V::AD, V::AD, phase_state)

--- a/src/multicomponent/variables/others.jl
+++ b/src/multicomponent/variables/others.jl
@@ -3,7 +3,7 @@ struct PhaseMassFractions{T} <: CompositionalFractions
 end
 
 @jutul_secondary function update_phase_xy!(X, m::PhaseMassFractions, model::SimulationModel{D,S}, FlashResults, ix) where {D,S<:CompositionalSystem}
-    molar_mass = map((x) -> x.mw, model.system.equation_of_state.mixture.properties)
+    molar_mass = MultiComponentFlash.molar_masses(model.system.equation_of_state)
     phase = m.phase
     @inbounds for i in ix
         f = FlashResults[i]

--- a/src/types.jl
+++ b/src/types.jl
@@ -32,7 +32,7 @@ const LVCompositionalModel3Phase = SimulationModel{D, S, F, C} where {D, S<:LVCo
 Set up a compositional system for a given `equation_of_state` from `MultiComponentFlash`.
 """
 function MultiPhaseCompositionalSystemLV(equation_of_state, phases = (LiquidPhase(), VaporPhase()); reference_densities = ones(length(phases)), other_name = "Water")
-    c = copy(equation_of_state.mixture.component_names)
+    c = MultiComponentFlash.component_names(equation_of_state)
     phases = tuple(phases...)
     T = typeof(phases)
     nph = length(phases)
@@ -60,8 +60,8 @@ function Base.show(io::IO, sys::MultiPhaseCompositionalSystemLV)
         name = "(no water)"
     end
     eos = sys.equation_of_state
-    cnames = join(eos.mixture.component_names, ", ")
-    print(io, "MultiPhaseCompositionalSystemLV $name with $(eos.type) EOS with $n components: $cnames")
+    cnames = join(MultiComponentFlash.component_names(eos), ", ")
+    print(io, "MultiPhaseCompositionalSystemLV $name with $(MultiComponentFlash.eostype(eos)) EOS with $n components: $cnames")
 end
 
 export StandardBlackOilSystem


### PR DESCRIPTION
with this, there is no internal calls to `eos.mixture`, all those are handled by functions instead. depends on https://github.com/moyner/MultiComponentFlash.jl/pull/18