### PR TITLE
Make sure rock and component heat capacities are set to DataDomain

### DIFF
--- a/src/utils.jl
+++ b/src/utils.jl
@@ -85,9 +85,11 @@ function reservoir_domain(g;
     )
     all(isfinite, permeability) || throw(ArgumentError("Keyword argument permeability has non-finite entries."))
     all(isfinite, porosity) || throw(ArgumentError("Keyword argument porosity has non-finite entries."))
+    all(isfinite, rock_thermal_conductivity) || throw(ArgumentError("Keyword argument rock_thermal_conductivity has non-finite entries."))
     all(isfinite, fluid_thermal_conductivity) || throw(ArgumentError("Keyword argument fluid_thermal_conductivity has non-finite entries."))
     all(isfinite, rock_heat_capacity) || throw(ArgumentError("Keyword argument rock_heat_capacity has non-finite entries."))
     all(isfinite, component_heat_capacity) || throw(ArgumentError("Keyword argument component_heat_capacity has non-finite entries."))
+    all(isfinite, rock_density) || throw(ArgumentError("Keyword argument rock_density has non-finite entries."))
 
     if !ismissing(diffusion)
         all(isfinite, diffusion) || throw(ArgumentError("Keyword argument diffusion has non-finite entries."))
@@ -108,6 +110,8 @@ function reservoir_domain(g;
         porosity = porosity,
         rock_thermal_conductivity = rock_thermal_conductivity,
         fluid_thermal_conductivity = fluid_thermal_conductivity,
+        rock_heat_capacity = rock_heat_capacity,
+        component_heat_capacity = component_heat_capacity,
         rock_density = rock_density,
         kwarg...
     )


### PR DESCRIPTION
This pull request includes fixes to the `reservoir_domain` function in the `src/utils.jl` file to ensure that heat capacities are set to the reservoir data domain, and adds missing validity checks.

Validation checks added:

* [`src/utils.jl`](diffhunk://#diff-47c27891e951c8cd946b850dc2df31082624afdf57446c21cb6992f5f4b74aa2R88-R92): Added checks to ensure that the `rock_thermal_conductivity` and `rock_density` keyword arguments have finite entries.

Keyword arguments added to the function call:

* [`src/utils.jl`](diffhunk://#diff-47c27891e951c8cd946b850dc2df31082624afdf57446c21cb6992f5f4b74aa2R113-R114): Included `rock_heat_capacity` and `component_heat_capacity` in the function call to ensure these parameters are passed correctly.