### PR TITLE
Make sure segment radius is set to wellbore radius multisegmenr wells

### DIFF
--- a/src/facility/wells/wells.jl
+++ b/src/facility/wells/wells.jl
@@ -150,6 +150,7 @@ function setup_well(g, K, reservoir_cells::AbstractVector;
     function get_entry(x, i)
         return x
     end
+    segment_radius = Float64[]
     for (i, c) in enumerate(reservoir_cells)
         if K isa AbstractVector
             k_i = K[c]
@@ -178,6 +179,7 @@ function setup_well(g, K, reservoir_cells::AbstractVector;
             end
             WIth_i::AbstractFloat
         end
+        push!(segment_radius, r_i)
         WIth_computed[i] = WIth_i
         center = vec(centers[:, i])
         dz[i] = center[3] - reference_depth
@@ -199,7 +201,10 @@ function setup_well(g, K, reservoir_cells::AbstractVector;
     else
         # Depth differences are taken care of via centers.
         dz *= 0.0
-        W = MultiSegmentWell(reservoir_cells, volumes, centers; WI = WI_computed, WIth = WIth_computed, dz = dz, reference_depth = reference_depth, kwarg...)
+        W = MultiSegmentWell(reservoir_cells, volumes, centers; 
+            WI = WI_computed, WIth = WIth_computed, dz = dz, 
+            reference_depth = reference_depth, segment_radius = segment_radius, 
+            kwarg...)
     end
     return W
 end

--- a/src/types.jl
+++ b/src/types.jl
@@ -501,6 +501,7 @@ function MultiSegmentWell(reservoir_cells, volumes::AbstractVector, centers;
             material_density = 8000.0,
             void_fraction = 1.0,
             extra_perforation_props = NamedTuple(),
+            segment_radius = 0.05,
             kwarg...
     )
     if isnothing(reference_depth)
@@ -538,6 +539,10 @@ function MultiSegmentWell(reservoir_cells, volumes::AbstractVector, centers;
         perforation_cells = collect(2:nc)
     end
     perforation_cells = vec(perforation_cells)
+    if segment_radius isa Real
+        segment_radius = fill(segment_radius, nseg)
+    end
+    @assert length(segment_radius) == nseg "Segment radius must have length equal to number of segments"
 
     # Process well material properties
     if length(material_thermal_conductivity) == 1
@@ -578,7 +583,8 @@ function MultiSegmentWell(reservoir_cells, volumes::AbstractVector, centers;
                     L = segment_length[seg]
                 end
             end
-            Δp = SegmentWellBoreFrictionHB(L, friction, 0.1)
+            diameter = segment_radius[seg]*2
+            Δp = SegmentWellBoreFrictionHB(L, friction, diameter)
             push!(segment_models, Δp)
         end
     else


### PR DESCRIPTION
This pull request introduces changes to the `setup_well` function and the `MultiSegmentWell` constructor to incorporate segment radius in the wellbore pressure drop model. 

Changes to `setup_well` function:

* [`src/facility/wells/wells.jl`](diffhunk://#diff-507a6b0ded459f955cb1b926b26f2638278794f6f5ee900f6babaeddd18d0442R153): Added initialization of `segment_radius` as an empty `Float64` array and populated it within the provided wellbore radii. [[1]](diffhunk://#diff-507a6b0ded459f955cb1b926b26f2638278794f6f5ee900f6babaeddd18d0442R153) [[2]](diffhunk://#diff-507a6b0ded459f955cb1b926b26f2638278794f6f5ee900f6babaeddd18d0442R182)
* [`src/facility/wells/wells.jl`](diffhunk://#diff-507a6b0ded459f955cb1b926b26f2638278794f6f5ee900f6babaeddd18d0442L202-R207): Updated the `MultiSegmentWell` call to include the new `segment_radius` parameter.

Changes to `MultiSegmentWell` constructor:

* [`src/types.jl`](diffhunk://#diff-525588e68b2421901be164965272940effa093de733a3fd36c4b9a4344b8c20cR504): Added `segment_radius` as a new parameter with a default value of `0.05`.
* [`src/types.jl`](diffhunk://#diff-525588e68b2421901be164965272940effa093de733a3fd36c4b9a4344b8c20cR542-R545): Ensured `segment_radius` is correctly sized to match the number of segments and added an assertion to check its length.
* [`src/types.jl`](diffhunk://#diff-525588e68b2421901be164965272940effa093de733a3fd36c4b9a4344b8c20cL581-R587): Modified the well bore friction calculation to use the diameter derived from `segment_radius` during construction