### PR TITLE
Timestepping updates

### DIFF
--- a/src/timesteps.jl
+++ b/src/timesteps.jl
@@ -1,7 +1,7 @@
 """
     ControlChangeTimestepSelector
     
-Timstep selector that limits timstep when well controls change more than
+Timestep selector that limits timestep when well controls change more than
 prescribed threshold. See constructor below.
 """
 mutable struct ControlChangeTimestepSelector <: Jutul.AbstractTimestepSelector

--- a/src/timesteps.jl
+++ b/src/timesteps.jl
@@ -41,14 +41,27 @@ end
 
 function Jutul.pick_next_timestep(sel::ControlChangeTimestepSelector, 
     sim, config, dt_prev, dT, forces, reports, current_reports, step_index, new_step)
+
+    change = false
+    wells = keys(sel.thresholds)
+
     # Get the current controls
-    curr_controls = forces[:Facility].control
+    if haskey(forces, :Facility)
+        curr_controls = forces[:Facility].control
+    else
+        curr_controls = Dict()
+        for well in wells
+            ctrl_name = Symbol(String(well)*"_ctrl")
+            curr_controls[well] = forces[ctrl_name].control[well]
+        end
+    end
+
+    # Get the previous controls
     if isnothing(sel.prev_controls)
         sel.prev_controls = curr_controls
         return sel.dt_after_change
     end
-    change = false
-    wells = keys(sel.thresholds)
+    
     for well in wells
         # Check if the control type has changed
         ctrl0 = sel.prev_controls[well]

--- a/src/timesteps.jl
+++ b/src/timesteps.jl
@@ -1,3 +1,9 @@
+"""
+    ControlChangeTimestepSelector
+    
+Timstep selector that limits timstep when well controls change more than
+prescribed threshold. See constructor below.
+"""
 mutable struct ControlChangeTimestepSelector <: Jutul.AbstractTimestepSelector
     thresholds::Dict
     dt_after_change::Float64
@@ -9,6 +15,16 @@ mutable struct ControlChangeTimestepSelector <: Jutul.AbstractTimestepSelector
 
 end
 
+"""
+    ControlChangeTimestepSelector(model::MultiModel, threshold = 0.25, dt_after_change = 5.0si_unit(:hour); wells = :all)
+
+Limit timestep if well controls change more than a threshold. The timestep is
+limited to `dt_after_change` if the control type or target value of any or the
+wells in `wells` changes more than `threshold`. The timestep selector can be
+configured to monitor a subset of the model wells with keyword argument `wells`.
+By default, `wells` is set to :all, in which case all wells in the model are
+used.
+"""
 function ControlChangeTimestepSelector(model::MultiModel, threshold = 0.25, dt_after_change = 5.0si_unit(:hour); wells = :all)
 
     all_wells = well_symbols(model)
@@ -39,6 +55,13 @@ function ControlChangeTimestepSelector(model::MultiModel, threshold = 0.25, dt_a
 
 end
 
+"""
+    Jutul.pick_next_timestep(sel::ControlChangeTimestepSelector, 
+    sim, config, dt_prev, dT, forces, reports, current_reports, step_index, new_step)
+
+Pick next timestep for the simulation based on changes in well controls. See
+`ControlChangeTimestepSelector` for details.
+"""
 function Jutul.pick_next_timestep(sel::ControlChangeTimestepSelector, 
     sim, config, dt_prev, dT, forces, reports, current_reports, step_index, new_step)
 
@@ -100,6 +123,7 @@ function Jutul.pick_next_timestep(sel::ControlChangeTimestepSelector,
             break
         end
     end
+
     # Update the previous controls
     sel.prev_controls = curr_controls
     # Update timetep if change has occured
@@ -108,6 +132,12 @@ function Jutul.pick_next_timestep(sel::ControlChangeTimestepSelector,
     
 end
 
+"""
+    Jutul.pick_next_timestep(sel::ControlChangeTimestepSelector, 
+    sim::NLDD.NLDDSimulator, config, dt_prev, dT, forces, reports, current_reports, step_index, new_step)
+
+Wrapper for NLDDSimulator.
+"""
 function Jutul.pick_next_timestep(sel::ControlChangeTimestepSelector, 
     sim::NLDD.NLDDSimulator, config, dt_prev, dT, forces, reports, current_reports, step_index, new_step)
 

--- a/src/timesteps.jl
+++ b/src/timesteps.jl
@@ -107,3 +107,12 @@ function Jutul.pick_next_timestep(sel::ControlChangeTimestepSelector,
     return ΔT
     
 end
+
+function Jutul.pick_next_timestep(sel::ControlChangeTimestepSelector, 
+    sim::NLDD.NLDDSimulator, config, dt_prev, dT, forces, reports, current_reports, step_index, new_step)
+
+    return Jutul.pick_next_timestep(
+        sel, sim.simulator, config, dt_prev, dT, forces.outer, reports, 
+        current_reports, step_index, new_step)
+
+end


### PR DESCRIPTION
This pull request enriches the `ControlChangeTimestepSelector` with support for cases where split_wells = true and for simulations using NLDD