### PR TITLE
Fix MRST-link in documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,7 +79,7 @@ All solvers can incorporate general multisegment wells with rigorous mass balanc
 ### Input/output and workflow tools
 
 - Support for reading in and running .DATA files with corner point grids, with support for non-conformal faults and inactive cells.
-- Unstructured grids and complex cases input from [the Matlab Reservoir Simulation Toolbox (MRST)](https://www.mrst.no) using the `jutul` module
+- Unstructured grids and complex cases input from [the Matlab Reservoir Simulation Toolbox (MRST)](https://www.sintef.no/projectweb/mrst/) using the `jutul` module
 - 3D visualization of grids and wells by loading a [Makie.jl](https://docs.makie.org/stable/) backend (requires Julia 1.9, `GLMakie` for interactivity)
 - Interactive plotting of well curves
 

--- a/docs/src/extras/faq.md
+++ b/docs/src/extras/faq.md
@@ -7,7 +7,7 @@ Here are a few common questions and possible answers. You may also want to have 
 ### What input formats can JutulDarcy.jl use?
 
 1. DATA files (used by Eclipse, OPM Flow, tNavigator, Echelon and others) provided that the grid is given either as a corner-point GRDECL file or in TOPS format. As with most reservoir simulators, not all features of the original format are supported, but the code will let you know when unsupported features are encountered.
-2. Cases written out from [MRST](https://www.mrst.no/) through the `jutul` module.
+2. Cases written out from [MRST](https://www.sintef.no/projectweb/mrst/) through the `jutul` module.
 3. Cases written entirely in Julia using the basic `Jutul` and `JutulDarcy` data structures, as seen in the examples of the module.
 
 ### What output formats does JutulDarcy.jl have?
@@ -172,7 +172,7 @@ The module is developed and maintained by the [Applied Computational Sciences gr
 
 ### Why write a new reservoir simulation code in Julia?
 
-We believe that reservoir simulation should be a *library* and not necessarily an application by itself. The future of porous media simulation is deeply integrated into other workflows, and not as an application that simply writes files to disk. As a part of experimentation in differentiable and flexible solvers using automatic differentiation that started with [MRST](https://www.mrst.no), Julia was the natural next step.
+We believe that reservoir simulation should be a *library* and not necessarily an application by itself. The future of porous media simulation is deeply integrated into other workflows, and not as an application that simply writes files to disk. As a part of experimentation in differentiable and flexible solvers using automatic differentiation that started with [MRST](https://www.sintef.no/projectweb/mrst/), Julia was the natural next step.
 
 ### What is the license of JutulDarcy.jl?
 

--- a/docs/src/man/highlevel.md
+++ b/docs/src/man/highlevel.md
@@ -13,7 +13,7 @@ The basic outline of building a reservoir simulation problem consists of:
 
 ### Meshes
 
-JutulDarcy can use meshes that are supported by Jutul. This includes the Cartesian ([`Jutul.CartesianMesh`](@ref)) and Unstructured meshes ([`Jutul.CartesianMesh`](@ref)), meshes from Gmsh ([`Jutul.mesh_from_gmsh`](@ref)), meshes from [MRST](https://www.mrst.no) ([`Jutul.MRSTWrapMesh`](@ref)), and meshes from the [Meshes.jl](https://github.com/JuliaGeometry/Meshes.jl) package.
+JutulDarcy can use meshes that are supported by Jutul. This includes the Cartesian ([`Jutul.CartesianMesh`](@ref)) and Unstructured meshes ([`Jutul.CartesianMesh`](@ref)), meshes from Gmsh ([`Jutul.mesh_from_gmsh`](@ref)), meshes from [MRST](https://www.sintef.no/projectweb/mrst/) ([`Jutul.MRSTWrapMesh`](@ref)), and meshes from the [Meshes.jl](https://github.com/JuliaGeometry/Meshes.jl) package.
 
 ### Reservoir
 


### PR DESCRIPTION
When reading the documentation, I found that the link to the MRST webside did not open properly (see screenshot). Switched to a different link that seems to work better.

<img width="1728" alt="Skjermbilde 2025-06-25 kl  09 44 29" src="https://github.com/user-attachments/assets/539e464e-803c-47c9-b910-8372fd36248c" />
