### PR TITLE
Add TotalProductionMassRateTarget well control

### DIFF
--- a/docs/src/man/basics/wells.md
+++ b/docs/src/man/basics/wells.md
@@ -57,6 +57,7 @@ HistoricalReservoirVoidageTarget
 ReservoirVoidageTarget
 DisabledTarget
 JutulDarcy.TotalReservoirRateTarget
+TotalProductionMassRateTarget
 ```
 
 ### Implementation of well controls

--- a/src/JutulDarcy.jl
+++ b/src/JutulDarcy.jl
@@ -54,7 +54,7 @@ module JutulDarcy
     export DisabledControl
     export Wells
     export TotalMassVelocityMassFractionsFlow
-    export BottomHolePressureTarget, TotalRateTarget
+    export BottomHolePressureTarget, TotalRateTarget, TotalProductionMassRateTarget
     export SinglePhaseRateTarget, DisabledTarget
     export SurfaceLiquidRateTarget, SurfaceOilRateTarget
     export SurfaceWaterRateTarget, SurfaceGasRateTarget

--- a/src/facility/controls.jl
+++ b/src/facility/controls.jl
@@ -196,6 +196,9 @@ function translate_limit(control::ProducerControl, name, val)
     elseif name == :resv
         v, w = val
         target_limit = ReservoirVoidageTarget(v, w)
+    elseif name == :pmrat
+        # Upper limit, total mass rate
+        target_limit = TotalProductionMassRateTarget(val)
     else
         error("$name limit not supported for well acting as producer.")
     end
@@ -364,6 +367,19 @@ function well_target(control::ProducerControl, target::SurfaceVolumeTarget, well
     end
     return w
 end
+
+
+"""
+Well target contribution for a producer with TotalProductionMassRateTarget.
+Always returns 1.0 so that `t = q_t` in `target_actual_pair`, i.e., the residual
+directly compares the actual total mass flow (kg/s) with the target value.
+"""
+
+function well_target(control::ProducerControl, target::TotalProductionMassRateTarget,
+                     well_model, well_state, surface_densities, surface_volume_fractions)
+    return 1.0
+end
+
 
 """
 Well target contribution from well itself (RESV, producer)

--- a/src/facility/types.jl
+++ b/src/facility/types.jl
@@ -250,6 +250,24 @@ struct TotalRateTarget{T} <: SurfaceVolumeTarget where T<:AbstractFloat
 end
 Base.show(io::IO, t::TotalRateTarget) = print(io, "TotalRateTarget with value $(t.value) [m^3/s]")
 
+
+
+"""
+    TotalProductionMassRateTarget(q)
+
+Well target of specified production mass rate with value `q`  (kg/s).
+
+"""
+struct  TotalProductionMassRateTarget{T} <: WellTarget where T<:AbstractFloat
+    value::T
+    function TotalProductionMassRateTarget(v::T) where T
+        if T == Float64
+            isfinite(v) || throw(ArgumentError("Mass rate must be finite, was $v"))
+        end
+        return new{T}(v)
+    end
+end
+
 """
     TotalReservoirRateTarget(q)
 
@@ -490,6 +508,7 @@ struct ProducerControl{T, R} <: WellControlForce
 end
 
 default_limits(f::ProducerControl{T}) where T<:SurfaceVolumeTarget = merge((bhp = DEFAULT_MINIMUM_PRESSURE,), as_limit(f.target)) # 1 atm
+default_limits(f::ProducerControl{T}) where T<:TotalProductionMassRateTarget = merge((bhp = DEFAULT_MINIMUM_PRESSURE,), as_limit(f.target)) # 1 atm
 default_limits(f::ProducerControl{T}) where T<:BottomHolePressureTarget = merge((rate_lower = -MIN_ACTIVE_WELL_RATE,), as_limit(f.target))
 
 function replace_target(f::ProducerControl, target)
@@ -828,6 +847,18 @@ function well_target_information(t::Val{:wcut})
         is_rate = false
     )
 end
+
+function well_target_information(t::Union{TotalProductionMassRateTarget, Val{:pmrat}})
+    return well_target_information(
+        symbol = :pmrat,
+        description = "Total production mass rate",
+        explanation = "Total mass rate of fluids produced by the well.",
+        unit_type = :mass,
+        unit_label = "kg/s",
+        is_rate = true
+    )
+end
+
 
 function realize_control_for_reservoir(state, ctrl, model, dt)
     return (ctrl, false)

--- a/src/facility/wellgroups.jl
+++ b/src/facility/wellgroups.jl
@@ -62,9 +62,11 @@ rate_weighted(t) = true
 rate_weighted(::BottomHolePressureTarget) = false
 rate_weighted(::DisabledTarget) = false
 
+
 target_scaling(::Any) = 1.0
 target_scaling(::BottomHolePressureTarget) = 1e5
 target_scaling(::SurfaceVolumeTarget) = 1.0/(3600*24.0) # weight by day
+target_scaling(::TotalProductionMassRateTarget) = 1.0/(3600*24.0) # weight by day
 
 Jutul.associated_entity(::ControlEquationWell) = Wells()
 Jutul.local_discretization(::ControlEquationWell, i) = nothing

--- a/src/forces/bc.jl
+++ b/src/forces/bc.jl
@@ -292,14 +292,6 @@ function compute_bc_heat_fluxes(bc, gmap, state, nph)
     return qh_advective, qh_conductive
 end
 
-# function compute_bc_heat_fluxes(bc, state)
-#     c = bc.cell
-#     T_f = bc.trans_flow
-#     Δp = p[c] - bc.pressure
-#     q = T_f*Δp
-#     return q
-# end
-
 function apply_flow_bc!(acc, q, bc, model::SimulationModel{<:Any, T}, state, time) where T<:Union{ImmiscibleSystem, SinglePhaseSystem}
 
     for ph in eachindex(acc)

--- a/test/nldd.jl
+++ b/test/nldd.jl
@@ -91,10 +91,10 @@ end
     end
 
     @testset "NLDD with BCs" begin
+        nc = 6
         function setup_bc_case(; thermal = false)
 
-            nc = 10
-            grid = CartesianMesh((nc, 1, 1), (1000.0, 1.0, 1.0))
+            grid = CartesianMesh((nc, 1, nc), (1000.0, 1.0, 1000.0))
 
             # Create domain and model
             domain = reservoir_domain(grid)
@@ -107,7 +107,7 @@ end
             p0, T0 = 10.0si_unit(:bar), convert_to_si(20.0, :Celsius)
             state0 = setup_reservoir_state(model; Pressure = p0, Temperature = T0)
 
-            bc = flow_boundary_condition([1, nc], domain,
+            bc = flow_boundary_condition([1, nc^2], domain,
                 [2*p0, p0], [T0 + 75.0, T0])
 
             forces = setup_reservoir_forces(model; bc = bc)

--- a/test/nldd.jl
+++ b/test/nldd.jl
@@ -90,6 +90,49 @@ end
         end
     end
 
+    @testset "NLDD with BCs" begin
+        function setup_bc_case(; thermal = false)
+
+            nc = 10
+            grid = CartesianMesh((nc, 1, 1), (1000.0, 1.0, 1.0))
+
+            # Create domain and model
+            domain = reservoir_domain(grid)
+            if thermal
+                sys = :geothermal
+            else
+                sys = SinglePhaseSystem(AqueousPhase(), reference_density = 1000.0)
+            end
+            model, = setup_reservoir_model(domain, sys)
+            p0, T0 = 10.0si_unit(:bar), convert_to_si(20.0, :Celsius)
+            state0 = setup_reservoir_state(model; Pressure = p0, Temperature = T0)
+
+            bc = flow_boundary_condition([1, nc], domain,
+                [2*p0, p0], [T0 + 75.0, T0])
+
+            forces = setup_reservoir_forces(model; bc = bc)
+
+            case = JutulCase(model, [1si_unit(:day)], forces, state0 = state0)
+
+            return case
+
+        end
+
+        function get_its(result)
+            Jutul.report_stats(result.result.reports).newtons
+        end
+
+        # for thermal = [false, true] # Fails for thermal = false (single-phase w/BCs)
+        for thermal = [true]
+            case = setup_bc_case(thermal = thermal)
+            results = simulate_reservoir(case;
+                method = :nldd, info_level = 2, max_timestep = Inf)
+            @test its == get_its(results)
+
+        end
+
+    end
+
     @testset "NLDD on MRST cases" begin
         for use_blocks in [true, false]
             test_on_mrst_case("spe1", use_blocks)

--- a/test/well_outputs.jl
+++ b/test/well_outputs.jl
@@ -9,6 +9,7 @@ using Test, JutulDarcy, Jutul, Dates
     @test JutulDarcy.translate_target_to_symbol(SurfaceGasRateTarget(1.0)) == :grat
     @test JutulDarcy.translate_target_to_symbol(ReservoirVoidageTarget(1.0, (0.2, 0.5, 0.3))) == :resv
     @test JutulDarcy.translate_target_to_symbol(HistoricalReservoirVoidageTarget(1.0, (0.2, 0.5, 0.3))) == :resv_history
+    @test JutulDarcy.translate_target_to_symbol(TotalProductionMassRateTarget(1.0)) == :pmrat
 end
 
 @testset "WellResults" begin


### PR DESCRIPTION
- Introduce `TotalProductionMassRateTarget` struct to specify production well mass flow (kg/s)
- Implement `well_target` contribution for this new target
- Add default limits and scaling in wellgroups for mass rate targets
- Extend tests to include target-to-symbol translation for mass rate
