### PR TITLE
Energy convergence

### DIFF
--- a/src/thermal/equations.jl
+++ b/src/thermal/equations.jl
@@ -78,17 +78,17 @@ Calculate the convergence criterion for the total thermal energy conservation la
 function Jutul.convergence_criterion(model, storage, eq::ConservationLaw{:TotalThermalEnergy}, eq_s, r; dt = 1.0, update_report = missing)
     a = active_entities(model.domain, Cells())
     E0 = storage.state0.TotalThermalEnergy
-    eb = 0.0
-    Etot = 0.0
-    ΔT = -Inf
+    eb, cnv, Etot = 0.0, -Inf, 0.0
     ΔT = temperature_increment(model, storage.state, update_report)
     for (i, c) in enumerate(a)
         eb += r[i]
+        cnv = max(cnv, abs(r[i])*dt/value(E0[c]))
         Etot += value(E0[c])
     end
     eb = abs(eb)*dt/Etot
 
     return (
+        CNV = (errors = (cnv, ), names = ("Max", )),
         EB = (errors = (eb, ), names = ("Energy balance", )), 
         increment_dT = (errors = (ΔT, ), names = ("ΔT", )),
         )

--- a/src/thermal/equations.jl
+++ b/src/thermal/equations.jl
@@ -78,9 +78,32 @@ Calculate the convergence criterion for the total thermal energy conservation la
 function Jutul.convergence_criterion(model, storage, eq::ConservationLaw{:TotalThermalEnergy}, eq_s, r; dt = 1.0, update_report = missing)
     a = active_entities(model.domain, Cells())
     E0 = storage.state0.TotalThermalEnergy
-    maxval = 0.0
+    eb = 0.0
+    Etot = 0.0
+    ΔT = -Inf
+    ΔT = temperature_increment(model, storage.state, update_report)
     for (i, c) in enumerate(a)
-        maxval = max(maxval, abs(r[i])*dt / value(E0[c]))
+        eb += r[i]
+        Etot += value(E0[c])
     end
-    return (Max = (errors = (maxval, ), names = ("Energy balance",)), )
+    eb = abs(eb)*dt/Etot
+
+    return (
+        EB = (errors = (eb, ), names = ("Energy balance", )), 
+        increment_dT = (errors = (ΔT, ), names = ("ΔT", )),
+        )
+end
+
+function temperature_increment(model, state, update_report)
+    t_report = update_report[:Temperature]
+    if haskey(t_report, :max)
+        v = t_report.max
+    else
+        v = 1.0
+    end
+    return v
+end
+
+function temperature_increment(model, state, update_report::Missing)
+    return 1.0
 end

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -927,9 +927,10 @@ function setup_reservoir_simulator(case::JutulCase;
         tol_dp_well = 1e-3,
         inc_tol_dp_abs = Inf,
         inc_tol_dp_rel = Inf,
+        inc_tol_dz = Inf,
+        inc_tol_dT = Inf,
         failure_cuts_timestep = true,
         max_timestep_cuts = 25,
-        inc_tol_dz = Inf,
         timesteps = :auto,
         relaxation = false,
         presolve_wells = false,
@@ -1055,7 +1056,8 @@ function setup_reservoir_simulator(case::JutulCase;
         tol_dp_well = tol_dp_well,
         inc_tol_dp_abs = inc_tol_dp_abs,
         inc_tol_dp_rel = inc_tol_dp_rel,
-        inc_tol_dz = inc_tol_dz
+        inc_tol_dz = inc_tol_dz,
+        inc_tol_dT = inc_tol_dT
         )
     return (sim, cfg)
 end
@@ -1153,7 +1155,8 @@ function set_default_cnv_mb_inner!(tol, model;
         tol_dp_well = 1e-3,
         inc_tol_dp_abs = Inf,
         inc_tol_dp_rel = Inf,
-        inc_tol_dz = Inf
+        inc_tol_dz = Inf,
+        inc_tol_dT = Inf
         )
     sys = model.system
     if model isa Jutul.CompositeModel && hasproperty(model.system.systems, :flow)
@@ -1181,6 +1184,13 @@ function set_default_cnv_mb_inner!(tol, model;
             increment_dp_rel = inc_tol_dp_rel,
             increment_dz = inc_tol_dz
         )
+        if haskey(model.equations, :energy_conservation)
+            tol[:energy_conservation] = (
+                CNV = c,
+                EB = m,
+                increment_dT = inc_tol_dT
+            )
+        end
     end
 end
 


### PR DESCRIPTION
This PR introduces proper convergence measures for the energy conservation equation, including maximum temperature increment, CNV and, energy balance (EB, similar to MB). Temperature increment tolerance defaults to Inf, whereas CNV/EB defaults to CNV/MB for mass conservation.