### PR TITLE
Multisegment well plotter updates

### DIFF
--- a/ext/JutulDarcyGLMakieExt/multisegment_well_plots.jl
+++ b/ext/JutulDarcyGLMakieExt/multisegment_well_plots.jl
@@ -163,7 +163,7 @@ function state_variable_unit_information(field::Symbol)
             symbol = :total_mass_flux,
             description = "Total mass flux",
             unit_type = :mass,
-            unit_label = "kg/s",
+            unit_label = "kg",
             is_rate = true
         )
     else
@@ -229,10 +229,10 @@ function JutulDarcy.plot_well_vs_meters_drilled!(ax, well_model, values;
 
     n_cells = number_of_cells(well_model.data_domain)
     n_segments = number_of_faces(well_model.data_domain)
+    N = get_neighborship(well_model.data_domain.representation)
     if length(values) == n_cells
         # OK
     elseif length(values) == n_segments
-        N = get_neighborship(well_model.data_domain.representation)
         meters_drilled = vec(sum(meters_drilled[N], dims=1)./2) # Average meters drilled for each segment
     else
         error("Length of values must match number of cells ($n_cells) or segments ($n_segments)")

--- a/ext/JutulDarcyGLMakieExt/multisegment_well_plots.jl
+++ b/ext/JutulDarcyGLMakieExt/multisegment_well_plots.jl
@@ -3,7 +3,7 @@
 
 # NOTE: This module was developed with the assistance of AI agent tools.
 
-"""r
+"""
     compute_meters_drilled(well_model)
 
 Compute meters drilled for each cell in a multisegment well.
@@ -60,7 +60,7 @@ function build_well_graph(centroids, neighborship)
         
         # Add edge in both directions (undirected graph)
         push!(adj_list[from_node], (to_node, dist))
-        push!(adj_list[to_node], (from_node, dist))
+        # push!(adj_list[to_node], (from_node, dist))
     end
     
     return adj_list
@@ -142,6 +142,64 @@ function compute_shortest_distances(graph, start_node, n_nodes)
 end
 
 """
+    state_variable_unit_information(field::Symbol)
+
+Return unit information for a state variable, similar to `well_target_information`.
+Returns `missing` if the variable is not recognized.
+"""
+function state_variable_unit_information(field::Symbol)
+    # Try well_target_information directly
+    info = JutulDarcy.well_target_information(field)
+    if !ismissing(info)
+        return info
+    end
+    # Map common state variable names to unit information
+    if field === :Pressure
+        return JutulDarcy.well_target_information(Val(:bhp))
+    elseif field === :Temperature
+        return JutulDarcy.well_target_information(Val(:temperature))
+    elseif field === :TotalMassFlux
+        return JutulDarcy.well_target_information(
+            symbol = :total_mass_flux,
+            description = "Total mass flux",
+            unit_type = :mass,
+            unit_label = "kg/s",
+            is_rate = true
+        )
+    else
+        return missing
+    end
+end
+
+"""
+    convert_state_field_values(values, field::Symbol, unit_sys::String)
+
+Convert state field values from SI to the specified unit system.
+Returns `(converted_values, unit_label)`.
+"""
+function convert_state_field_values(values, field::Symbol, unit_sys::String)
+    info = state_variable_unit_information(field)
+    if ismissing(info)
+        return values, string(field)
+    end
+    lbl = info.unit_label
+    is_rate = info.is_rate
+    factor = 1.0
+    f_u, lbl = well_unit_conversion(unit_sys, lbl, info)
+    if f_u isa Symbol
+        values = convert_from_si.(values, f_u)
+    else
+        factor *= f_u
+    end
+    if is_rate
+        lbl *= "/day"
+        factor *= si_unit(:day)
+    end
+    values = factor .* values
+    return values, lbl
+end
+
+"""
     plot_well_vs_meters_drilled!(ax, well_model, values; label=nothing, kwargs...)
 
 Plot well data vs meters drilled on the given axis.
@@ -159,7 +217,8 @@ If the well has sections (`:section` key), each section is plotted with a distin
 Otherwise, plots all values as a single line.
 """
 function JutulDarcy.plot_well_vs_meters_drilled!(ax, well_model, values;
-    label=nothing, colors = missing, meters_drilled=missing, kwargs...)
+    label=nothing, colors = missing, meters_drilled=missing,
+    unit_sys="SI", field_name=missing, kwargs...)
     # Compute meters drilled for each cell if not provided
     if ismissing(meters_drilled)
         meters_drilled = compute_meters_drilled(well_model)
@@ -177,6 +236,12 @@ function JutulDarcy.plot_well_vs_meters_drilled!(ax, well_model, values;
         meters_drilled = vec(sum(meters_drilled[N], dims=1)./2) # Average meters drilled for each segment
     else
         error("Length of values must match number of cells ($n_cells) or segments ($n_segments)")
+    end
+
+    # Apply unit conversion if field_name is provided
+    if !ismissing(field_name)
+        values, unit_label = convert_state_field_values(values, Symbol(field_name), unit_sys)
+        ax.ylabel = unit_label
     end
 
     if has_sections
@@ -244,10 +309,12 @@ fig = plot_well_vs_meters_drilled(well_model, temperature_values,
 function JutulDarcy.plot_well_vs_meters_drilled(well_model, values; 
                                     figure_kwargs=NamedTuple(), 
                                     axis_kwargs=NamedTuple(), 
+                                    unit_sys="SI",
+                                    field_name=missing,
                                     kwargs...)
     fig = Figure(; figure_kwargs...)
     ax = Axis(fig[1, 1]; axis_kwargs...)
-    JutulDarcy.plot_well_vs_meters_drilled!(ax, well_model, values; kwargs...)
+    JutulDarcy.plot_well_vs_meters_drilled!(ax, well_model, values; unit_sys=unit_sys, field_name=field_name, kwargs...)
     if haskey(well_model.data_domain, :section)
         Legend(fig[1, 2], ax, "Sections")
     end
@@ -281,6 +348,7 @@ Interactive GUI for plotting multisegment well data vs meters drilled.
 function JutulDarcy.plot_well_states_interactive(well_model, states; 
                                      time=missing, 
                                      names=missing, 
+                                     unit_sys="Metric",
                                      resolution=(1200, 800), 
                                      kwargs...)
     
@@ -331,6 +399,7 @@ function JutulDarcy.plot_well_states_interactive(well_model, states;
     n_states = length(states)
     state_index = Observable{Int}(1)
     field_selection = Observable{String}(valid_fields[1])
+    unit_sys_obs = Observable{String}(unit_sys)
     is_playing = Observable{Bool}(false)
     play_speed = Observable{Float64}(1.0)  # States per second
     
@@ -350,8 +419,12 @@ function JutulDarcy.plot_well_states_interactive(well_model, states;
     field_menu = Menu(fig, options=valid_fields, default=valid_fields[1], width=150)
     on(field_menu.selection) do s
         field_selection[] = s
-        # Update axis label
-        ax.ylabel = s
+    end
+
+    # Unit system menu
+    unit_menu = Menu(fig, options=["Metric", "SI", "Field"], default=unit_sys_obs[], width=100)
+    on(unit_menu.selection) do s
+        unit_sys_obs[] = s
     end
     
     # Time stepping controls
@@ -413,23 +486,26 @@ function JutulDarcy.plot_well_states_interactive(well_model, states;
     end
     
     on(reset_y_button.clicks) do _
-        # Reset y-axis to full range of current field
+        # Reset y-axis to full range of current field (converted to current unit system)
         field = field_selection[]
         y_min, y_max = field_y_limits[field]
-        ylims!(ax, y_min, y_max)
+        lims, _ = convert_state_field_values([y_min, y_max], Symbol(field), unit_sys_obs[])
+        ylims!(ax, lims[1], lims[2])
     end
     
     # Layout controls
     control_layout[1, 1] = Label(fig, "Field:", halign=:right)
     control_layout[1, 2] = field_menu
-    control_layout[1, 3] = Label(fig, "Time step:")
-    control_layout[1, 4] = time_slider
-    control_layout[1, 5] = play_button
-    control_layout[1, 6] = Label(fig, "Speed:")
-    control_layout[1, 7] = speed_input
-    control_layout[1, 8] = reset_button
-    control_layout[1, 9] = reset_x_button
-    control_layout[1, 10] = reset_y_button
+    control_layout[1, 3] = Label(fig, "Units:")
+    control_layout[1, 4] = unit_menu
+    control_layout[1, 5] = Label(fig, "Time step:")
+    control_layout[1, 6] = time_slider
+    control_layout[1, 7] = play_button
+    control_layout[1, 8] = Label(fig, "Speed:")
+    control_layout[1, 9] = speed_input
+    control_layout[1, 10] = reset_button
+    control_layout[1, 11] = reset_x_button
+    control_layout[1, 12] = reset_y_button
     
     # Animation timer
     animation_timer = Timer(0.1)  # Will be started/stopped as needed
@@ -478,20 +554,25 @@ function JutulDarcy.plot_well_states_interactive(well_model, states;
     function update_plot()
         idx = state_index[]
         field = field_selection[]
+        usys = unit_sys_obs[]
         
         # Clear existing plots
         empty!(ax)
         
         # Get current state and field data  
         current_state = states[idx]
-        field_data = current_state[Symbol(field)]
+        field_data = Float64.(current_state[Symbol(field)])
+        
+        # Convert units
+        field_data, unit_label = convert_state_field_values(field_data, Symbol(field), usys)
         
         # Plot data vs meters drilled (with section support)
         JutulDarcy.plot_well_vs_meters_drilled!(ax, well_model, field_data; meters_drilled=meters_drilled, kwargs...)
         
-        # Set consistent y-axis limits
+        # Set consistent y-axis limits (convert from SI)
         y_min, y_max = field_y_limits[field]
-        ylims!(ax, y_min, y_max)
+        lims, _ = convert_state_field_values([y_min, y_max], Symbol(field), usys)
+        ylims!(ax, lims[1], lims[2])
         
         # Update title
         title_str = if n_states > 1
@@ -509,16 +590,20 @@ function JutulDarcy.plot_well_states_interactive(well_model, states;
         end
         ax.title = title_str
         
-        # Update axis label
-        ax.ylabel = field
+        # Update axis label with unit
+        ax.ylabel = unit_label
     end
     
-    # Listen to both observables
+    # Listen to state, field, and unit system observables
     on(state_index) do _
         update_plot()
     end
     
     on(field_selection) do _
+        update_plot()
+    end
+    
+    on(unit_sys_obs) do _
         update_plot()
     end
     

--- a/ext/JutulDarcyGLMakieExt/multisegment_well_plots.jl
+++ b/ext/JutulDarcyGLMakieExt/multisegment_well_plots.jl
@@ -218,7 +218,7 @@ Otherwise, plots all values as a single line.
 """
 function JutulDarcy.plot_well_vs_meters_drilled!(ax, well_model, values;
     label=nothing, colors = missing, meters_drilled=missing,
-    unit_sys="SI", field_name=missing, kwargs...)
+    unit_sys="SI", field_name=missing, section_labels=missing, kwargs...)
     # Compute meters drilled for each cell if not provided
     if ismissing(meters_drilled)
         meters_drilled = compute_meters_drilled(well_model)
@@ -266,10 +266,15 @@ function JutulDarcy.plot_well_vs_meters_drilled!(ax, well_model, values;
         for s in 1:num_sections
             cell_mask = sections .== s
             if any(cell_mask)  # Only plot if section has cells
-                section_label = if isnothing(label)
-                    "Section $s"
+                base_label = if !ismissing(section_labels)
+                    section_labels[s]
                 else
-                    "$label - Section $s"
+                    "Section $s"
+                end
+                section_label = if isnothing(label)
+                    base_label
+                else
+                    "$label - $base_label"
                 end
                 
                 lines!(ax, meters_drilled[cell_mask], values[cell_mask]; 
@@ -311,10 +316,11 @@ function JutulDarcy.plot_well_vs_meters_drilled(well_model, values;
                                     axis_kwargs=NamedTuple(), 
                                     unit_sys="SI",
                                     field_name=missing,
+                                    section_labels=missing,
                                     kwargs...)
     fig = Figure(; figure_kwargs...)
     ax = Axis(fig[1, 1]; axis_kwargs...)
-    JutulDarcy.plot_well_vs_meters_drilled!(ax, well_model, values; unit_sys=unit_sys, field_name=field_name, kwargs...)
+    JutulDarcy.plot_well_vs_meters_drilled!(ax, well_model, values; unit_sys=unit_sys, field_name=field_name, section_labels=section_labels, kwargs...)
     if haskey(well_model.data_domain, :section)
         Legend(fig[1, 2], ax, "Sections")
     end
@@ -349,6 +355,7 @@ function JutulDarcy.plot_well_states_interactive(well_model, states;
                                      time=missing, 
                                      names=missing, 
                                      unit_sys="Metric",
+                                     section_labels=missing,
                                      resolution=(1200, 800), 
                                      kwargs...)
     
@@ -567,7 +574,7 @@ function JutulDarcy.plot_well_states_interactive(well_model, states;
         field_data, unit_label = convert_state_field_values(field_data, Symbol(field), usys)
         
         # Plot data vs meters drilled (with section support)
-        JutulDarcy.plot_well_vs_meters_drilled!(ax, well_model, field_data; meters_drilled=meters_drilled, kwargs...)
+        JutulDarcy.plot_well_vs_meters_drilled!(ax, well_model, field_data; meters_drilled=meters_drilled, section_labels=section_labels, kwargs...)
         
         # Set consistent y-axis limits (convert from SI)
         y_min, y_max = field_y_limits[field]
@@ -642,7 +649,11 @@ function JutulDarcy.plot_well_states_interactive(well_model, states;
             section_colors = cgrad(:BrBg, n_sections, categorical = true)
         end
         entries = [LineElement(color = section_colors[s], linewidth = 3) for s in 1:n_sections]
-        labels = ["Section $s" for s in 1:n_sections]
+        labels = if !ismissing(section_labels)
+            [section_labels[s] for s in 1:n_sections]
+        else
+            ["Section $s" for s in 1:n_sections]
+        end
         Legend(fig[2:4, 4], entries, labels, "Sections")
     end
     

--- a/ext/JutulDarcyGLMakieExt/multisegment_well_plots.jl
+++ b/ext/JutulDarcyGLMakieExt/multisegment_well_plots.jl
@@ -248,6 +248,8 @@ function JutulDarcy.plot_well_vs_meters_drilled!(ax, well_model, values;
         sections = well_model.data_domain[:section]
         if length(values) == n_segments
             sections = max.(sections[N[1,:]], sections[N[2,:]])
+            joints = findall(sections[N[1,:]] .!= sections[N[2,:]])
+            sections[joints] .= -1  # Assign a new section for joints
         end
         num_sections = maximum(sections)
         if ismissing(colors)
@@ -408,7 +410,7 @@ function JutulDarcy.plot_well_states_interactive(well_model, states;
     field_selection = Observable{String}(valid_fields[1])
     unit_sys_obs = Observable{String}(unit_sys)
     is_playing = Observable{Bool}(false)
-    play_speed = Observable{Float64}(1.0)  # States per second
+    play_speed = Observable{Float64}(10.0)  # States per second
     
     # Create figure and layout
     fig = Figure(size=resolution)
@@ -462,8 +464,8 @@ function JutulDarcy.plot_well_states_interactive(well_model, states;
     play_button = Button(fig, label="Play", width=80)
     
     # Speed control
-    speed_input = Textbox(fig, placeholder="1.0", width=60, validator=s -> tryparse(Float64, s) !== nothing)
-    speed_input.stored_string = "1.0"
+    speed_input = Textbox(fig, placeholder="10.0", width=60, validator=s -> tryparse(Float64, s) !== nothing)
+    speed_input.stored_string = "10.0"
     
     on(speed_input.stored_string) do s
         val = tryparse(Float64, s)
@@ -472,13 +474,13 @@ function JutulDarcy.plot_well_states_interactive(well_model, states;
         end
     end
     
-    # Reset button
-    reset_button = Button(fig, label="Reset", width=60)
-    on(reset_button.clicks) do _
-        state_index[] = 1
-        is_playing[] = false
-        play_button.label = "Play"
-    end
+    # # Reset button
+    # reset_button = Button(fig, label="Reset", width=60)
+    # on(reset_button.clicks) do _
+    #     state_index[] = 1
+    #     is_playing[] = false
+    #     play_button.label = "Play"
+    # end
     
     # Axis reset buttons
     reset_x_button = Button(fig, label="Reset X", width=70)
@@ -486,18 +488,28 @@ function JutulDarcy.plot_well_states_interactive(well_model, states;
     
     on(reset_x_button.clicks) do _
         # Reset x-axis to full range of meters drilled
+        limits = deepcopy(ax.finallimits[])
+        # Access individual ranges
+        current_ylims = (limits.origin[2], limits.origin[2] + limits.widths[2])
         x_min, x_max = extrema(meters_drilled)
         x_range = x_max - x_min
         x_padding = max(x_range * 0.02, eps(Float64))
         xlims!(ax, x_min - x_padding, x_max + x_padding)
+        # Restore y zoom
+        ylims!(ax, current_ylims...)
     end
     
     on(reset_y_button.clicks) do _
         # Reset y-axis to full range of current field (converted to current unit system)
+        limits = deepcopy(ax.finallimits[])
+        # Access individual ranges
+        current_xlims = (limits.origin[1], limits.origin[1] + limits.widths[1])
         field = field_selection[]
         y_min, y_max = field_y_limits[field]
         lims, _ = convert_state_field_values([y_min, y_max], Symbol(field), unit_sys_obs[])
         ylims!(ax, lims[1], lims[2])
+        # Restore x zoom
+        xlims!(ax, current_xlims...)
     end
     
     # Layout controls
@@ -510,9 +522,9 @@ function JutulDarcy.plot_well_states_interactive(well_model, states;
     control_layout[1, 7] = play_button
     control_layout[1, 8] = Label(fig, "Speed:")
     control_layout[1, 9] = speed_input
-    control_layout[1, 10] = reset_button
-    control_layout[1, 11] = reset_x_button
-    control_layout[1, 12] = reset_y_button
+    # control_layout[1, 10] = reset_button
+    control_layout[1, 10] = reset_x_button
+    control_layout[1, 11] = reset_y_button
     
     # Animation timer
     animation_timer = Timer(0.1)  # Will be started/stopped as needed
@@ -558,10 +570,16 @@ function JutulDarcy.plot_well_states_interactive(well_model, states;
     end
     
     # Main plotting logic - reactive to state and field changes
-    function update_plot()
+    function update_plot(; reset_limits = false)
         idx = state_index[]
         field = field_selection[]
         usys = unit_sys_obs[]
+        
+        # Save current zoom before clearing
+        limits = deepcopy(ax.finallimits[])
+        # Access individual ranges
+        current_xlims = (limits.origin[1], limits.origin[1] + limits.widths[1])
+        current_ylims = (limits.origin[2], limits.origin[2] + limits.widths[2])
         
         # Clear existing plots
         empty!(ax)
@@ -576,21 +594,28 @@ function JutulDarcy.plot_well_states_interactive(well_model, states;
         # Plot data vs meters drilled (with section support)
         JutulDarcy.plot_well_vs_meters_drilled!(ax, well_model, field_data; meters_drilled=meters_drilled, section_labels=section_labels, kwargs...)
         
-        # Set consistent y-axis limits (convert from SI)
-        y_min, y_max = field_y_limits[field]
-        lims, _ = convert_state_field_values([y_min, y_max], Symbol(field), usys)
-        ylims!(ax, lims[1], lims[2])
+        if reset_limits
+            # Set y-axis limits from global field range (convert from SI)
+            y_min, y_max = field_y_limits[field]
+            lims, _ = convert_state_field_values([y_min, y_max], Symbol(field), usys)
+            ylims!(ax, lims[1], lims[2])
+        else
+            # Restore previous zoom
+            xlims!(ax, current_xlims...)
+            ylims!(ax, current_ylims...)
+        end
         
-        # Update title
+        # Update title with time in days
         title_str = if n_states > 1
             if ismissing(time)
                 "$field - Step $idx/$n_states"
             else
-                if time[idx] isa DateTime
-                    "$field - $(time[idx])"
+                t_days = if time[idx] isa DateTime
+                    time[idx]
                 else
-                    "$field - Time: $(round(time[idx], digits=2))"
+                    round(time[idx] / si_unit(:day), digits=2)
                 end
+                "$field - Step $idx/$n_states - $t_days days"
             end
         else
             field
@@ -607,11 +632,11 @@ function JutulDarcy.plot_well_states_interactive(well_model, states;
     end
     
     on(field_selection) do _
-        update_plot()
+        update_plot(reset_limits = true)
     end
     
     on(unit_sys_obs) do _
-        update_plot()
+        update_plot(reset_limits = true)
     end
     
     # Information panel (top right)
@@ -658,7 +683,7 @@ function JutulDarcy.plot_well_states_interactive(well_model, states;
     end
     
     # Trigger initial plot
-    notify(state_index)
+    update_plot(reset_limits = true)
     
     return fig
 end


### PR DESCRIPTION
Several bugfixes and improvements, including:
* Added `state_variable_unit_information` and `convert_state_field_values` functions to provide unit information and 
* Added a unit system dropdown menu to the interactive GUI, allowing users to switch between "Metric", "SI", and "Field" units on the fly, with all plots and axis labels updating reactively. 
* Added support for custom `section_labels` in plotting functions and legends, allowing for more descriptive section names in plots and the interactive GUI.
* Increased the default play speed in the interactive GUI for smoother animation, and updated speed input placeholder accordingly.
* Commented out the reset button for state index in the interactive GUI, streamlining the controls.