### PR TITLE
NLDD sweeps

### DIFF
--- a/src/NLDD/simulator.jl
+++ b/src/NLDD/simulator.jl
@@ -684,11 +684,8 @@ function global_stage(
         end
     end
     if all_local_converged && (iteration > config[:min_nonlinear_iterations]) && config[:subdomain_tol_sufficient]
-        # report[:secondary_time] = 0.0
-        # report[:equations_time] = 0.0
-        # report[:linear_system_time] = 0.0
         report[:converged] = true
-        # report[:convergence_time] = 0.0
+        report[:solved] = false
         Jutul.extra_debug_output!(report, s.storage, s.model, config, iteration, dt)
         out = (0.0, true, report)
         il = config[:info_level]

--- a/src/NLDD/simulator.jl
+++ b/src/NLDD/simulator.jl
@@ -946,7 +946,7 @@ function Jutul.perform_step_per_process_initial_update!(simulator::NLDDSimulator
         if !isnothing(solve_tol)
             update_state_mirror!(simulator.storage.state_mirror, state_prev, s.model, solve_tol)
         end
-        if all(st .== local_solve_skipped)
+        if all(st .== local_solve_skipped .|| st .== local_already_converged)
             break
         end
     end

--- a/src/NLDD/simulator.jl
+++ b/src/NLDD/simulator.jl
@@ -172,7 +172,7 @@ function Jutul.perform_step!(
         )
     end
     active = report[:local_solves_active][end]
-    subreports = report[:subdomains]
+    subreports = report[:subdomains][end]
     status = report[:solve_status][end]
 
     e = NaN

--- a/src/NLDD/simulator.jl
+++ b/src/NLDD/simulator.jl
@@ -673,7 +673,6 @@ function global_stage(
     # If all subdomains converged, we can return early
     all_local_converged = true
     any_failures = false
-    println("Hei")
     if isnothing(subreports)
         all_local_converged = false
     else

--- a/src/NLDD/simulator.jl
+++ b/src/NLDD/simulator.jl
@@ -171,7 +171,7 @@ function Jutul.perform_step!(
             executor = executor
         )
     end
-    active = report[:local_solves_active][end]
+    active = report[:local_solves_active]
     subreports = report[:subdomains][end]
     status = report[:solve_status][end]
 
@@ -922,7 +922,9 @@ function Jutul.perform_step_per_process_initial_update!(simulator::NLDDSimulator
     status = []
     for sweep_no in 1:config[:nldd_max_sweeps]
         st = [local_solve_skipped for i in eachindex(simulator.subdomain_simulators)]
-        state_prev = deepcopy(s.storage.state)
+        if config[:nldd_max_sweeps] > 1
+            state_prev = deepcopy(s.storage.state)
+        end
         @tic "local" if (active && config[:solve_subdomains])
                 sr, so, ts, st, f = local_stage(base_arg..., sweep_no)
         else

--- a/src/NLDD/utils.jl
+++ b/src/NLDD/utils.jl
@@ -51,6 +51,7 @@ function simulator_config(sim::NLDDSimulator;
         types = Symbol,
         values = [:linear, :pressure, :potential, :adaptive]
     )
+    add_option!(cfg, :nldd_max_sweeps, 1, "Maximum number of NLDD sweeps", types = Int)
     add_option!(cfg, :method, method, "Method to use", values = [:nldd, :aspen], types = Symbol)
     add_option!(cfg, :debug_checks, false, "Enable extra expensive checks", types = Bool)
     add_option!(cfg, :solve_subdomains, true, "Solve subdomains", types = Bool)

--- a/src/NLDD/utils.jl
+++ b/src/NLDD/utils.jl
@@ -256,54 +256,6 @@ function subdomain_report_stats(sim, reports)
     return Jutul.output_report_stats(stats)
 end
 
-function subdomain_solve_count(sim, reports)
-    n = length(sim.subdomain_simulators)
-    failure_count = 0
-    count = 0
-    nldd_count = 0
-    total_count = 0
-    subdomain_skipped = 0
-    subdomain_solves = 0
-    subdomain_total = 0
-    for r in reports
-        for m in r[:ministeps]
-            if haskey(m, :steps)
-                for mr in m[:steps]
-                    if haskey(mr, :subdomain_failures)
-                        failures = mr[:subdomain_failures]
-                        if isnothing(failures)
-                            continue
-                        end
-                        failure_count += length(failures)
-                        count += 1
-                    end
-                    if !mr[:converged]
-                        total_count += 1
-                        nldd_count += mr[:local_solves_active]
-                    end
-                    if haskey(mr, :solve_status)
-                        for status in mr[:solve_status]
-                            subdomain_skipped += status == local_solve_skipped
-                            subdomain_solves += status != local_already_converged && status != local_solve_skipped
-                            subdomain_total += 1
-                        end
-                    end
-                end
-            end
-        end
-    end
-
-    count = (
-        total=total_count,
-        nldd=nldd_count,
-        solved=subdomains_solved,
-        skipped=subdomains_skipped,
-        solved_total
-    )
-
-    return nldd_count, total_count
-end
-
 import JutulDarcy: reservoir_partition
 
 function build_submodels(model, partition; active_global = missing, specialize = false)

--- a/src/NLDD/utils.jl
+++ b/src/NLDD/utils.jl
@@ -172,23 +172,26 @@ function final_simulation_message(sim::NLDDSimulator, p, rec, t_elapsed, reports
         for m in r[:ministeps]
             if haskey(m, :steps)
                 for mr in m[:steps]
-                    if haskey(mr, :subdomain_failures)
-                        failures = mr[:subdomain_failures]
-                        if isnothing(failures)
-                            continue
-                        end
-                        failure_count += length(failures)
-                        count += 1
-                    end
                     if !mr[:converged]
                         total_count += 1
                         nldd_count += mr[:local_solves_active]
                     end
-                    if haskey(mr, :solve_status)
-                        for status in mr[:solve_status]
-                            subdomain_skipped += status == local_solve_skipped
-                            subdomain_solves += status != local_already_converged && status != local_solve_skipped
-                            subdomain_total += 1
+                    num_sweeps = length(mr[:subdomains])
+                    for sno in 1:num_sweeps
+                        if haskey(mr, :subdomain_failures)
+                            failures = mr[:subdomain_failures][sno]
+                            if isnothing(failures)
+                                continue
+                            end
+                            failure_count += length(failures)
+                            count += 1
+                        end
+                        if haskey(mr, :solve_status)
+                            for status in mr[:solve_status][sno]
+                                subdomain_skipped += status == local_solve_skipped
+                                subdomain_solves += status != local_already_converged && status != local_solve_skipped
+                                subdomain_total += 1
+                            end
                         end
                     end
                 end

--- a/src/NLDD/utils.jl
+++ b/src/NLDD/utils.jl
@@ -256,6 +256,54 @@ function subdomain_report_stats(sim, reports)
     return Jutul.output_report_stats(stats)
 end
 
+function subdomain_solve_count(sim, reports)
+    n = length(sim.subdomain_simulators)
+    failure_count = 0
+    count = 0
+    nldd_count = 0
+    total_count = 0
+    subdomain_skipped = 0
+    subdomain_solves = 0
+    subdomain_total = 0
+    for r in reports
+        for m in r[:ministeps]
+            if haskey(m, :steps)
+                for mr in m[:steps]
+                    if haskey(mr, :subdomain_failures)
+                        failures = mr[:subdomain_failures]
+                        if isnothing(failures)
+                            continue
+                        end
+                        failure_count += length(failures)
+                        count += 1
+                    end
+                    if !mr[:converged]
+                        total_count += 1
+                        nldd_count += mr[:local_solves_active]
+                    end
+                    if haskey(mr, :solve_status)
+                        for status in mr[:solve_status]
+                            subdomain_skipped += status == local_solve_skipped
+                            subdomain_solves += status != local_already_converged && status != local_solve_skipped
+                            subdomain_total += 1
+                        end
+                    end
+                end
+            end
+        end
+    end
+
+    count = (
+        total=total_count,
+        nldd=nldd_count,
+        solved=subdomains_solved,
+        skipped=subdomains_skipped,
+        solved_total
+    )
+
+    return nldd_count, total_count
+end
+
 import JutulDarcy: reservoir_partition
 
 function build_submodels(model, partition; active_global = missing, specialize = false)

--- a/src/NLDD/utils.jl
+++ b/src/NLDD/utils.jl
@@ -228,17 +228,21 @@ function subdomain_report_stats(sim, reports)
             end
             for rep in mini_rep[:steps]
                 if haskey(rep, :subdomains)
-                    stats[:time] += rep[:time_subdomains]
-                    for i = 1:N
-                        if !haskey(rep, :subdomains) || isnothing(rep[:subdomains])
+                    stats[:time] += sum(rep[:time_subdomains])
+                    num_sweeps = length(rep[:subdomains])
+                    for sno in 1:num_sweeps
+                        sweep_rep = rep[:subdomains][sno]
+                        if isnothing(sweep_rep)
                             continue
                         end
-                        R = rep[:subdomains][i]
-                        if isnothing(R)
-                            continue
-                        end
-                        for step_rep in R
-                            Jutul.ministep_report_stats!(stats, step_rep)
+                        for i = 1:N
+                            R = sweep_rep[i]
+                            if isnothing(R)
+                                continue
+                            end
+                            for step_rep in R
+                                Jutul.ministep_report_stats!(stats, step_rep)
+                            end
                         end
                     end
                 end

--- a/src/NLDD/utils.jl
+++ b/src/NLDD/utils.jl
@@ -162,7 +162,6 @@ function count_nldd_solve_statistics(reports)
     
     # Initialize counters
     failure_count = 0
-    failure_attempts = 0
     nldd_count = 0
     total_count = 0
     subdomain_skipped = 0
@@ -197,7 +196,6 @@ function count_nldd_solve_statistics(reports)
                                 if !isnothing(failures)
                                     has_failure_data = true
                                     failure_count += length(failures)
-                                    failure_attempts += 1
                                 end
                             end
                             
@@ -228,7 +226,6 @@ function count_nldd_solve_statistics(reports)
         nldd_count = nldd_count,
         total_count = total_count,
         failure_count = failure_count,
-        failure_attempts = failure_attempts,
         subdomain_skipped = subdomain_skipped,
         subdomain_solves = subdomain_solves,
         subdomain_total = subdomain_total,
@@ -255,14 +252,16 @@ function print_nldd_solve_statistics(stats, n_subdomains, method, info_level)
         
         # Print subdomain status statistics
         if stats.has_status_data
-            Jutul.jutul_message("NLDD", "Subdomain status:\n\t$(stats.subdomain_skipped)/$(stats.subdomain_total) local solves were skipped.\n\t$(stats.subdomain_already_conv)/$(stats.subdomain_total) local solves were already converged.\n\t$(stats.subdomain_solves)/$(stats.subdomain_total) local solves were solved.")
+            Jutul.jutul_message("NLDD", "Subdomain status:\
+            \n\t$(stats.subdomain_skipped)/$(stats.subdomain_total) local problems were skipped.\
+            \n\t$(stats.subdomain_already_conv)/$(stats.subdomain_total) local problems were already converged.\
+            \n\t$(stats.subdomain_solves)/$(stats.subdomain_total) local problems were solved.")
         end
     end
     
     # Always print failure information if there are failures
     if stats.has_failure_data && stats.failure_count > 0
-        total_local_solves = n_subdomains * stats.failure_attempts
-        @info "$(stats.failure_count) subdomain solves failed out of $total_local_solves total local solves."
+        @info "$(stats.failure_count) subdomain solves failed out of $(stats.subdomain_solves) total local solves."
     end
 end
 

--- a/test/nldd.jl
+++ b/test/nldd.jl
@@ -188,7 +188,7 @@ end
         end
 
         # 5. Enough multi-sweeps should ensure convergence in a single outer iteration
-        @testset "nldd_max_sweeps = 1000 should converge to FI solution" begin
+        @testset "nldd_max_sweeps = 1000 should converge in one FI iteration" begin
             results = simulate_reservoir(case[1:5]; method = :nldd,
                 nldd_arg = nldd_arg, 
                 nldd_max_sweeps = 1000,

--- a/test/nldd.jl
+++ b/test/nldd.jl
@@ -169,32 +169,17 @@ end
             @test get_prod_bhp(ws_1)  ≈ get_prod_bhp(ws_default)  rtol = 0
         end
 
-        # 2. Multi-sweep (2 and 3) must reproduce Newton to simulation tolerance
-        @testset "nldd_max_sweeps = $ns matches Newton" for ns in [2, 3]
+        # 2. Multi-sweep (2 and 10) must reproduce Newton to simulation tolerance
+        @testset "nldd_max_sweeps = $ns matches Newton" for ns in [2, 10]
             ws, = simulate_reservoir(case, method = :nldd, nldd_max_sweeps = ns, nldd_arg = nldd_arg; args...)
             @test get_prod_rate(ws) ≈ get_prod_rate(ws_newton) rtol = 1e-2
             @test get_prod_bhp(ws)  ≈ get_prod_bhp(ws_newton)  rtol = 1e-2
         end
 
-        # 3. Multi-sweep should not increase outer Newton iteration count
-        @testset "nldd_max_sweeps should not increase outer iterations" begin
-            get_its = r -> Jutul.report_stats(r.result.reports).newtons
-            case_mrst, = setup_case_from_mrst("spe1",
-                split_wells = true, ds_max = 0.1, block_backend = true)
-            case_mrst = case_mrst[1:5]
-            push!(case_mrst.model[:Reservoir].output_variables, :Saturations)
-            sim_arg = (info_level = -1, timesteps = :iteration,
-                       error_on_incomplete = true, nldd_arg = (no_blocks = 4,))
-            its_1 = get_its(simulate_reservoir(case_mrst, method = :nldd; sim_arg...))
-            its_2 = get_its(simulate_reservoir(case_mrst, method = :nldd,
-                nldd_max_sweeps = 2; sim_arg...))
-            @test its_2 <= its_1
-        end
-
         # 4. Gauss-Seidel + multi-sweep must give correct results for all ordering strategies
         @testset "Gauss-Seidel + nldd_max_sweeps = 2, order = $order" for order in [:pressure, :linear, :potential]
             ws, = simulate_reservoir(case, method = :nldd,
-                nldd_max_sweeps = 2,
+                nldd_max_sweeps = 5,
                 gauss_seidel = true,
                 gauss_seidel_order = order,
                 nldd_arg = nldd_arg; args...)
@@ -202,18 +187,17 @@ end
             @test get_prod_bhp(ws)  ≈ get_prod_bhp(ws_newton)  rtol = 1e-2
         end
 
-        # 5. Enough multi-sweeps should converge to the FI solution
+        # 5. Enough multi-sweeps should ensure convergence in a single outer iteration
         @testset "nldd_max_sweeps = 1000 should converge to FI solution" begin
-            sim, cfg = setup_reservoir_simulator(case, method = :nldd, nldd_arg = nldd_arg; args...)
-            
-            [c[:info_level]=2 for c in cfg[:config_subdomains]]
-
-            results = simulate_reservoir(case[1:5], method = :nldd,
+            results = simulate_reservoir(case[1:5]; method = :nldd,
+                nldd_arg = nldd_arg, 
                 nldd_max_sweeps = 1000,
                 gauss_seidel = true,
-                nldd_arg = nldd_arg; args..., simulator=sim, config = cfg, info_level=2)
-            @test get_prod_rate(ws) ≈ get_prod_rate(ws_newton) rtol = 1e-2
-            @test get_prod_bhp(ws)  ≈ get_prod_bhp(ws_newton)  rtol = 1e-2
+                inner_tol_mul=1e-1, inner_tol_final=1.0, args...   
+                )
+            # Global nonlinear iterations per ministep should be 1
+            stats = report_stats(results.result.reports)
+            @test stats.newtons == stats.ministeps
         end
 
     end

--- a/test/nldd.jl
+++ b/test/nldd.jl
@@ -149,4 +149,72 @@ end
         test_on_mrst_case("egg", true, steps = 1:5)
         test_on_mrst_case("spe9", true, steps = 1:5)
     end
+
+    @testset "NLDD multi-sweep (nldd_max_sweeps)" begin
+        f = JutulDarcy.GeoEnergyIO.test_input_file_path("SPE1", "SPE1.DATA")
+        case = setup_case_from_data_file(f, split_wells = true)
+        args = (info_level = -1, error_on_incomplete = true)
+        nldd_arg = (no_blocks = 4,)
+
+        get_prod_rate(ws) = ws[:PROD, :rate]
+        get_prod_bhp(ws)  = ws[:PROD, :bhp]
+
+        ws_newton, = simulate_reservoir(case, method = :newton; args...)
+        ws_default, = simulate_reservoir(case, method = :nldd; nldd_arg = nldd_arg, args...)
+
+        # 1. nldd_max_sweeps = 1 must be identical to the default (regression guard)
+        @testset "nldd_max_sweeps = 1 matches default" begin
+            ws_1, = simulate_reservoir(case, method = :nldd, nldd_max_sweeps = 1, nldd_arg = nldd_arg; args...)
+            @test get_prod_rate(ws_1) ≈ get_prod_rate(ws_default) rtol = 0
+            @test get_prod_bhp(ws_1)  ≈ get_prod_bhp(ws_default)  rtol = 0
+        end
+
+        # 2. Multi-sweep (2 and 3) must reproduce Newton to simulation tolerance
+        @testset "nldd_max_sweeps = $ns matches Newton" for ns in [2, 3]
+            ws, = simulate_reservoir(case, method = :nldd, nldd_max_sweeps = ns, nldd_arg = nldd_arg; args...)
+            @test get_prod_rate(ws) ≈ get_prod_rate(ws_newton) rtol = 1e-2
+            @test get_prod_bhp(ws)  ≈ get_prod_bhp(ws_newton)  rtol = 1e-2
+        end
+
+        # 3. Multi-sweep should not increase outer Newton iteration count
+        @testset "nldd_max_sweeps should not increase outer iterations" begin
+            get_its = r -> Jutul.report_stats(r.result.reports).newtons
+            case_mrst, = setup_case_from_mrst("spe1",
+                split_wells = true, ds_max = 0.1, block_backend = true)
+            case_mrst = case_mrst[1:5]
+            push!(case_mrst.model[:Reservoir].output_variables, :Saturations)
+            sim_arg = (info_level = -1, timesteps = :iteration,
+                       error_on_incomplete = true, nldd_arg = (no_blocks = 4,))
+            its_1 = get_its(simulate_reservoir(case_mrst, method = :nldd; sim_arg...))
+            its_2 = get_its(simulate_reservoir(case_mrst, method = :nldd,
+                nldd_max_sweeps = 2; sim_arg...))
+            @test its_2 <= its_1
+        end
+
+        # 4. Gauss-Seidel + multi-sweep must give correct results for all ordering strategies
+        @testset "Gauss-Seidel + nldd_max_sweeps = 2, order = $order" for order in [:pressure, :linear, :potential]
+            ws, = simulate_reservoir(case, method = :nldd,
+                nldd_max_sweeps = 2,
+                gauss_seidel = true,
+                gauss_seidel_order = order,
+                nldd_arg = nldd_arg; args...)
+            @test get_prod_rate(ws) ≈ get_prod_rate(ws_newton) rtol = 1e-2
+            @test get_prod_bhp(ws)  ≈ get_prod_bhp(ws_newton)  rtol = 1e-2
+        end
+
+        # 5. Enough multi-sweeps should converge to the FI solution
+        @testset "nldd_max_sweeps = 1000 should converge to FI solution" begin
+            sim, cfg = setup_reservoir_simulator(case, method = :nldd, nldd_arg = nldd_arg; args...)
+            
+            [c[:info_level]=2 for c in cfg[:config_subdomains]]
+
+            results = simulate_reservoir(case[1:5], method = :nldd,
+                nldd_max_sweeps = 1000,
+                gauss_seidel = true,
+                nldd_arg = nldd_arg; args..., simulator=sim, config = cfg, info_level=2)
+            @test get_prod_rate(ws) ≈ get_prod_rate(ws_newton) rtol = 1e-2
+            @test get_prod_bhp(ws)  ≈ get_prod_bhp(ws_newton)  rtol = 1e-2
+        end
+
+    end
 end


### PR DESCRIPTION
This pull request introduces support for multiple sweeps in the local stage of nonlinear domain decomposition (NLDD) per time step. It adds a new configuration option to control the maximum number of sweeps, updates the core solver logic and reporting to handle multi-sweep runs, and includes tests to validate the new behavior. Additionally, the code for collecting and reporting NLDD statistics is refactored for clarity and accuracy.

**NLDD Multi-sweep Support and Solver Changes:**

- Added a new configuration option `nldd_max_sweeps` to control the maximum number of NLDD sweeps per time step, and updated the solver logic to perform multiple sweeps as configured. This includes proper handling of subdomain reports, statuses, and state updates for each sweep. [[1]](diffhunk://#diff-51c01f8dbf3bd08e2318dee05357408c472ef864f5168e829e43e796d41cc214R54) [[2]](diffhunk://#diff-b5c236632bce262e9721035d48567672a001819aabb040bb3f0e6e0be88e10e7L234-R234) [[3]](diffhunk://#diff-b5c236632bce262e9721035d48567672a001819aabb040bb3f0e6e0be88e10e7R917-R950) [[4]](diffhunk://#diff-b5c236632bce262e9721035d48567672a001819aabb040bb3f0e6e0be88e10e7R359-R368) [[5]](diffhunk://#diff-b5c236632bce262e9721035d48567672a001819aabb040bb3f0e6e0be88e10e7L175-R176)
- Updated the `local_stage` and related functions to accept and utilize the sweep number, and improved logging to indicate the current sweep in progress. [[1]](diffhunk://#diff-b5c236632bce262e9721035d48567672a001819aabb040bb3f0e6e0be88e10e7L234-R234) [[2]](diffhunk://#diff-b5c236632bce262e9721035d48567672a001819aabb040bb3f0e6e0be88e10e7R359-R368)
- Adjusted the global convergence logic to properly handle the new multi-sweep structure, ensuring correct reporting of convergence and solved status.

**Statistics and Reporting Improvements:**

- Refactored the collection and reporting of NLDD solve statistics, including the number of sweeps, subdomain solves, skips, failures, and convergence status, to support and accurately reflect multi-sweep runs. This includes new helper functions for counting and printing statistics. [[1]](diffhunk://#diff-51c01f8dbf3bd08e2318dee05357408c472ef864f5168e829e43e796d41cc214L152-R205) [[2]](diffhunk://#diff-51c01f8dbf3bd08e2318dee05357408c472ef864f5168e829e43e796d41cc214L197-R283)
- Updated subdomain statistics aggregation to correctly sum over all sweeps and subdomains, ensuring accurate timing and iteration reporting. [[1]](diffhunk://#diff-51c01f8dbf3bd08e2318dee05357408c472ef864f5168e829e43e796d41cc214L230-R317) [[2]](diffhunk://#diff-51c01f8dbf3bd08e2318dee05357408c472ef864f5168e829e43e796d41cc214R329)

**Testing Enhancements:**

- Added tests for the new multi-sweep functionality, including regression checks for single-sweep behavior, correctness of multi-sweep results, Gauss-Seidel ordering with sweeps, and a test to ensure sufficient sweeps guarantee convergence in a single outer iteration.