### PR TITLE
Forward states/reports kwargs in simulate_reservoir

### DIFF
--- a/src/utils.jl
+++ b/src/utils.jl
@@ -1304,6 +1304,8 @@ function simulate_reservoir(case::JutulCase;
         config = missing,
         restart = false,
         simulator = missing,
+        states = Vector{Jutul.JUTUL_OUTPUT_TYPE}(),
+        reports = [],
         kwarg...
     )
     (; model, forces, state0, parameters, dt) = case
@@ -1325,7 +1327,15 @@ function simulate_reservoir(case::JutulCase;
         extra_arg = (state0 = case.state0, parameters = case.parameters)
         @assert !ismissing(config) "If simulator is provided, config must also be provided"
     end
-    result = simulate!(sim, dt; forces = forces, config = config, restart = restart, start_date = case.start_date, extra_arg...)
+    result = simulate!(sim, dt;
+        forces = forces,
+        config = config,
+        restart = restart,
+        start_date = case.start_date,
+        states = states,
+        reports = reports,
+        extra_arg...,
+    )
     return ReservoirSimResult(model, result, forces; simulator = sim, config = config, start_date = case.start_date)
 end
 


### PR DESCRIPTION
Companion to sintefmath/Jutul.jl#301, which adds `states=` / `reports=` kwargs to `simulate!` and `initial_setup!`.

`simulate_reservoir`'s catch-all `kwarg...` currently routes to `setup_reservoir_simulator`, so passing `states=` / `reports=` through would have those silently swallowed before reaching `simulate!`. This PR lifts them to explicit named kwargs and threads them through to the `simulate!` call.

Defaults are fresh empty containers (`Vector{Jutul.JUTUL_OUTPUT_TYPE}()` and `[]`), preserving existing behavior.

Depends on sintefmath/Jutul.jl#301 — needs to merge after that lands and the compat is bumped.

11 insertions, 1 deletion.