### PR TITLE
Enthalpy formulation

### DIFF
--- a/src/Geothermal/Geothermal.jl
+++ b/src/Geothermal/Geothermal.jl
@@ -1,7 +1,7 @@
 module Geothermal
 
     using Jutul, JutulDarcy
-    export BTESWellSupplyToReturnMassCT, ClosedLoopSupplyToReturnEnergyCT, BTESWellGroutEnergyCT
+    export BTESWellSupplyToReturnMassCT, ClosedLoopSupplyToReturnEnergyCT
     export update_cross_term_in_entity!
 
     function JutulDarcy.setup_reservoir_model(reservoir::DataDomain, ::Val{:geothermal}; kwarg...)

--- a/src/Geothermal/wells/cross_terms.jl
+++ b/src/Geothermal/wells/cross_terms.jl
@@ -36,18 +36,6 @@ struct ClosedLoopSupplyToReturnEnergyCT <: AbstractClosedLoopCT
     end
 end
 
-struct BTESWellGroutEnergyCT <: AbstractClosedLoopCT
-    WIth_grout::Vector{Float64}
-    supply_nodes::Vector{Int64}
-    return_nodes::Vector{Int64}
-    function BTESWellGroutEnergyCT(WIth_grout::Vector{Float64}, supply_nodes::Vector{Int64}, return_nodes::Vector{Int64})
-        if length(supply_nodes) != length(return_nodes)
-            throw(ArgumentError("Supply and return nodes must have the same length"))
-        end
-        new(WIth_grout, supply_nodes, return_nodes)
-    end
-end
-
 ## Cross term calculations for BTES wells
 
 function JutulDarcy.update_cross_term_in_entity!(out, i,
@@ -190,25 +178,4 @@ Base.@propagate_inbounds function btes_supply_return_heatflux(system::JutulDarcy
     end
    
     return q
-end
-
-function JutulDarcy.update_cross_term_in_entity!(out, i,
-    state_t, state0_t,
-    state_s, state0_s, 
-    model_t, model_s,
-    ct::BTESWellGroutEnergyCT, eq, dt, ldisc = JutulDarcy.local_discretization(ct, i))
-
-    # Unpack properties
-    sys = model_t.system
-    @inbounds begin 
-        supply_node = ct.supply_nodes[i]
-        return_node = ct.return_nodes[i]
-        λ = ct.WIth_grout[i]
-        T_s = state_s.Temperature[supply_node]
-        T_t = state_t.Temperature[return_node]
-        λ = ct.WIth_grout[i]
-        q = -λ.*(T_t - T_s)
-    end
-
-    out[] = q
 end

--- a/src/Geothermal/wells/cross_terms.jl
+++ b/src/Geothermal/wells/cross_terms.jl
@@ -157,7 +157,7 @@ Base.@propagate_inbounds function btes_supply_return_heatflux(system::JutulDarcy
     ncomp = JutulDarcy.number_of_components(system)
     q = 0.0
     has_enthalpy = haskey(state_supply, :Enthalpy) && haskey(state_return, :Enthalpy)
-    function enthalpy(comp, state, node)
+    function enthalpy(state, node)
         if has_enthalpy
             return state.Enthalpy[node]
         else
@@ -165,14 +165,16 @@ Base.@propagate_inbounds function btes_supply_return_heatflux(system::JutulDarcy
             h_v = state.FluidEnthalpy[2, node]
             S_l = state.Saturations[1, node]
             S_v = state.Saturations[2, node]
-            return S_l*h_l + S_v*h_v
+            ρ_l = state.PhaseMassDensities[1, node]
+            ρ_v = state.PhaseMassDensities[2, node]
+            return (h_l*S_l*ρ_l + h_v*S_v*ρ_v)/(S_l*ρ_l + S_v*ρ_v)
         end
     end
     for comp in 1:ncomp
         if q_comp[comp] < 0
-            h_comp = enthalpy(comp, state_supply, supply_node)
+            h_comp = enthalpy(state_supply, supply_node)
         else
-            h_comp = enthalpy(comp, state_return, return_node)
+            h_comp = enthalpy(state_return, return_node)
         end
         q += q_comp[comp]*h_comp
     end

--- a/src/Geothermal/wells/cross_terms.jl
+++ b/src/Geothermal/wells/cross_terms.jl
@@ -61,10 +61,9 @@ function JutulDarcy.update_cross_term_in_entity!(out, i,
     @inbounds begin 
         supply_node = ct.supply_nodes[i]
         return_node = ct.return_nodes[i]
-        nph = number_of_phases(sys)
-        for ph in 1:nph
-            q_ph = btes_supply_return_massflux(state_s, state_t, supply_node, return_node, ph)
-            out[ph] = q_ph
+        q = btes_supply_return_massflux(sys, state_s, state_t, supply_node, return_node)
+        for j in eachindex(out)
+            out[j] = q[j]
         end
 
     end
@@ -82,44 +81,115 @@ function JutulDarcy.update_cross_term_in_entity!(out, i,
     @inbounds begin 
         supply_node = ct.supply_nodes[i]
         return_node = ct.return_nodes[i]
-        nph = number_of_phases(sys)
-        q = 0.0
-        for ph in 1:nph
-            q_ph = btes_supply_return_massflux(state_s, state_t, supply_node, return_node, ph)
-            if q_ph < 0
-                h_ph = state_s.FluidEnthalpy[ph, supply_node]
-            else
-                h_ph = state_t.FluidEnthalpy[ph, return_node]
-            end
-            q += q_ph.*h_ph
-        end
+        q = btes_supply_return_heatflux(sys, state_s, state_t, supply_node, return_node)
     end
     out[] = q
 
 end
 
-Base.@propagate_inbounds function btes_supply_return_massflux(state_supply, state_return, supply_node, return_node, ph)
+Base.@propagate_inbounds function btes_supply_return_massflux(system::JutulSystem, state_supply, state_return, supply_node, return_node)
 
+    T = 1.0e-10
     p_s = state_supply.Pressure[supply_node]
     p_t = state_return.Pressure[return_node]
     dp = p_s - p_t
-
-    T = 1.0e-10
     Ψ = -T*dp
 
+    nph = number_of_phases(system)
+    S = Base.promote_type(typeof(Ψ), typeof(p_s), typeof(p_t))
+    q = zeros(S, nph)
     if dp > 0
-        ρ = state_supply.PhaseMassDensities[ph, supply_node]
-        s = state_supply.Saturations[ph, supply_node]
-        μ = state_supply.PhaseViscosities[ph, supply_node]
+        state, node = state_supply, supply_node
     else
-        ρ = state_return.PhaseMassDensities[ph, return_node]
-        s = state_return.Saturations[ph, return_node]
-        μ = state_return.PhaseViscosities[ph, return_node]
+        state, node = state_return, return_node
+    end
+    for ph in 1:nph
+        ρ = state.PhaseMassDensities[ph, node]
+        s = state.Saturations[ph, node]
+        μ = state.PhaseViscosities[ph, node]
+        q[ph] = (s*ρ/μ)*Ψ
     end
 
-    q_ph = (s*ρ/μ)*Ψ
+    return q
+end
 
-    return q_ph
+Base.@propagate_inbounds function btes_supply_return_massflux(system::JutulDarcy.AbstractCompositionalSystemLV, state_supply, state_return, supply_node, return_node)
+
+    T = 1.0e-10
+    p_s = state_supply.Pressure[supply_node]
+    p_t = state_return.Pressure[return_node]
+    dp = p_s - p_t
+    Ψ = -T*dp
+
+    nph = number_of_phases(system)
+    ncomp = JutulDarcy.number_of_components(system)
+    S = Base.promote_type(typeof(Ψ), typeof(p_s), typeof(p_t))
+    q = zeros(S, ncomp)
+    if dp > 0
+        state, node = state_supply, supply_node
+    else
+        state, node = state_return, return_node
+    end
+    λ_t = 0.0
+    rho_mix = 0.0
+    for ph in 1:nph
+        λ_t += state.Saturations[ph, node]/state.PhaseViscosities[ph, node]
+        rho_mix += state.Saturations[ph, node]*state.PhaseMassDensities[ph, node]
+    end
+    mass_t = 0.0
+    for i = 1:ncomp
+        mass_t += state.TotalMasses[i, node]
+    end
+    for i = 1:ncomp
+        f = state.TotalMasses[i, node]/mass_t
+        q[i] = f*λ_t*rho_mix*Ψ
+    end
+
+    return q
+end
+
+Base.@propagate_inbounds function btes_supply_return_heatflux(system::JutulSystem, state_supply, state_return, supply_node, return_node)
+    q_ph = btes_supply_return_massflux(system, state_supply, state_return, supply_node, return_node)
+    nph = number_of_phases(system)
+    q = 0.0
+    for ph in 1:nph
+        if q_ph[ph] < 0
+            h_ph = state_supply.FluidEnthalpy[ph, supply_node]
+        else
+            h_ph = state_return.FluidEnthalpy[ph, return_node]
+        end
+        q += q_ph[ph]*h_ph
+    end
+   
+    return q
+end
+
+Base.@propagate_inbounds function btes_supply_return_heatflux(system::JutulDarcy.AbstractCompositionalSystemLV, state_supply, state_return, supply_node, return_node)
+    q_comp = btes_supply_return_massflux(system, state_supply, state_return, supply_node, return_node)
+    ncomp = JutulDarcy.number_of_components(system)
+    q = 0.0
+    has_enthalpy = haskey(state_supply, :Enthalpy) && haskey(state_return, :Enthalpy)
+    function enthalpy(comp, state, node)
+        if has_enthalpy
+            return state.Enthalpy[node]
+        else
+            h_l = state.FluidEnthalpy[1, node]
+            h_v = state.FluidEnthalpy[2, node]
+            S_l = state.Saturations[1, node]
+            S_v = state.Saturations[2, node]
+            return S_l*h_l + S_v*h_v
+        end
+    end
+    for comp in 1:ncomp
+        if q_comp[comp] < 0
+            h_comp = enthalpy(comp, state_supply, supply_node)
+        else
+            h_comp = enthalpy(comp, state_return, return_node)
+        end
+        q += q_comp[comp]*h_comp
+    end
+   
+    return q
 end
 
 function JutulDarcy.update_cross_term_in_entity!(out, i,

--- a/src/Geothermal/wells/cross_terms.jl
+++ b/src/Geothermal/wells/cross_terms.jl
@@ -101,7 +101,7 @@ Base.@propagate_inbounds function btes_supply_return_massflux(system::JutulSyste
     return q
 end
 
-Base.@propagate_inbounds function btes_supply_return_massflux(system::JutulDarcy.AbstractCompositionalSystemLV, state_supply, state_return, supply_node, return_node)
+Base.@propagate_inbounds function btes_supply_return_massflux(system::JutulDarcy.CompositionalSystemLV, state_supply, state_return, supply_node, return_node)
 
     T = 1.0e-10
     p_s = state_supply.Pressure[supply_node]
@@ -152,7 +152,7 @@ Base.@propagate_inbounds function btes_supply_return_heatflux(system::JutulSyste
     return q
 end
 
-Base.@propagate_inbounds function btes_supply_return_heatflux(system::JutulDarcy.AbstractCompositionalSystemLV, state_supply, state_return, supply_node, return_node)
+Base.@propagate_inbounds function btes_supply_return_heatflux(system::JutulDarcy.CompositionalSystemLV, state_supply, state_return, supply_node, return_node)
     q_comp = btes_supply_return_massflux(system, state_supply, state_return, supply_node, return_node)
     ncomp = JutulDarcy.number_of_components(system)
     q = 0.0

--- a/src/JutulDarcy.jl
+++ b/src/JutulDarcy.jl
@@ -211,7 +211,7 @@ module JutulDarcy
 
     # Geothermal
     include("Geothermal/Geothermal.jl")
-    import JutulDarcy.Geothermal: ClosedLoopSupplyToReturnMassCT, ClosedLoopSupplyToReturnEnergyCT, BTESWellGroutEnergyCT
+    import JutulDarcy.Geothermal: ClosedLoopSupplyToReturnMassCT, ClosedLoopSupplyToReturnEnergyCT
 
     # Discrete Fracture Models
     include("DFM/cross_terms.jl")

--- a/src/facility/cross_terms.jl
+++ b/src/facility/cross_terms.jl
@@ -471,7 +471,7 @@ function update_cross_term_in_entity!(out, i,
     pos = get_well_position(facility.domain, ct.well)
     H = 0*state_facility[:SurfaceEnthalpy][pos]
     H += well_top_node_enthalpy(well, state_well, well_top_node())
-    out[1] = -H
+    out[1] = -H*eq.scale
 end
 
 struct FacilityFromWellBottomHolePressureCT <: Jutul.AdditiveCrossTerm

--- a/src/facility/cross_terms.jl
+++ b/src/facility/cross_terms.jl
@@ -335,9 +335,35 @@ function update_cross_term_in_entity!(out, i,
 
     cell = well_top_node()
 
-    T = get_target_temperature(ctrl, ctrl.target, facility, state_facility)
-    H = well_top_node_enthalpy(ctrl, well, state_well, T, cell)
+    H = get_target_enthalpy(ctrl, ctrl.target, facility, state_facility, well, state_well, cell)
     out[] = -qT*H
+end
+
+function get_target_enthalpy(ctrl, target, facility, state_facility, model, state_well, cell)
+    return well_top_node_enthalpy(model, state_well, cell)
+end
+
+function get_target_enthalpy(ctrl::InjectorControl, target, facility, state_facility, model, state_well, cell)
+    T = get_target_temperature(ctrl, target, facility, state_facility)
+    return well_top_node_enthalpy(ctrl, model, state_well, T, cell)
+end
+
+function get_target_enthalpy(ctrl::InjectorControl, target::ReinjectionTarget, facility, state_facility, model, state_well, cell)
+    if !ismissing(ctrl.enthalpy) || !isnan(ctrl.temperature)
+        T = get_target_temperature(ctrl, target, facility, state_facility)
+        return well_top_node_enthalpy(ctrl, model, state_well, T, cell)
+    end
+
+    q = qh = Htot = 0.0
+    for w in target.wells
+        pos = get_well_position(facility.domain, w)
+        qw = state_facility.TotalSurfaceMassRate[pos]
+        Hw = state_facility.SurfaceEnthalpy[pos]
+        q += qw
+        qh += qw*Hw
+        Htot += Hw
+    end
+    return ifelse(abs(q) >= MIN_ACTIVE_WELL_RATE, qh/q, Htot/length(target.wells))
 end
 
 function get_target_temperature(ctrl, target, facility, state_facility)
@@ -349,11 +375,6 @@ function get_target_temperature(ctrl::InjectorControl, target, facility, state_f
 end
 
 function get_target_temperature(ctrl::InjectorControl, target::ReinjectionTarget, facility, state_facility)
-
-    # TODO: This currently assumes constant fluid heat capacity and equal
-    # pressures. Should ideally be replaced by enthalpy, which requires
-    # FluidEnthalpy to be a Facility variable
-
     if !isnan(ctrl.temperature)
         return ctrl.temperature
     end
@@ -370,6 +391,23 @@ function get_target_temperature(ctrl::InjectorControl, target::ReinjectionTarget
     T = ifelse(abs(q) >= MIN_ACTIVE_WELL_RATE, qh/q, Ttot/length(target.wells))
 
     return T
+end
+
+function well_top_node_enthalpy(model, state_well, cell)
+    if haskey(state_well, :Enthalpy)
+        return state_well.Enthalpy[cell]
+    end
+    H = state_well.FluidEnthalpy
+    if haskey(state_well, :Saturations)
+        S = state_well.Saturations
+        H_w = zero(H[1, cell])
+        for ph in axes(H, 1)
+            H_w += H[ph, cell]*S[ph, cell]
+        end
+    else
+        H_w = H[1, cell]
+    end
+    return H_w
 end
 
 function well_top_node_enthalpy(ctrl::InjectorControl, model, state_well, T, cell)
@@ -397,13 +435,7 @@ function well_top_node_enthalpy(ctrl::InjectorControl, model, state_well, T, cel
 end
 
 function well_top_node_enthalpy(ctrl, model, state_well, T, cell)
-    H = state_well.FluidEnthalpy
-    S = state_well.Saturations
-    H_w = 0.0
-    for ph in axes(H, 1)
-        H_w += H[ph, cell]*S[ph, cell]
-    end
-    return H_w
+    return well_top_node_enthalpy(model, state_well, cell)
 end
 
 struct FacilityFromWellTemperatureCT <: Jutul.AdditiveCrossTerm
@@ -422,6 +454,24 @@ function update_cross_term_in_entity!(out, i,
     T = 0*state_facility[:SurfaceTemperature][pos]
     T += state_well[:Temperature][well_top_node()]
     out[1] = -T
+end
+
+struct FacilityFromWellEnthalpyCT <: Jutul.AdditiveCrossTerm
+    well::Symbol
+end
+
+Jutul.cross_term_entities(ct::FacilityFromWellEnthalpyCT, eq::SurfaceEnthalpyEquation, model) = get_well_position(model.domain, ct.well)
+
+function update_cross_term_in_entity!(out, i,
+    state_facility, state0_facility,
+    state_well, state0_well,
+    facility, well,
+    ct::FacilityFromWellEnthalpyCT, eq::SurfaceEnthalpyEquation, dt, ldisc = local_discretization(ct, i))
+
+    pos = get_well_position(facility.domain, ct.well)
+    H = 0*state_facility[:SurfaceEnthalpy][pos]
+    H += well_top_node_enthalpy(well, state_well, well_top_node())
+    out[1] = -H
 end
 
 struct FacilityFromWellBottomHolePressureCT <: Jutul.AdditiveCrossTerm

--- a/src/facility/types.jl
+++ b/src/facility/types.jl
@@ -146,6 +146,23 @@ function Jutul.relative_increment_limit(T::SurfaceTemperature)
     return T.max_relative_change
 end
 
+Base.@kwdef struct SurfaceEnthalpy <: ScalarVariable
+    "Maximum absolute change betweeen two Newton updates (nominally J/kg)"
+    max_absolute_change::Union{Float64, Nothing} = nothing
+    "Maximum relative change between two Newton updates."
+    max_relative_change::Union{Float64, Nothing} = nothing
+    min = 0.0
+    max = 1e12
+end
+
+function Jutul.absolute_increment_limit(H::SurfaceEnthalpy)
+    return H.max_absolute_change
+end
+
+function Jutul.relative_increment_limit(H::SurfaceEnthalpy)
+    return H.max_relative_change
+end
+
 abstract type WellTarget end
 abstract type SurfaceVolumeTarget <: WellTarget end
 
@@ -850,6 +867,11 @@ end
 struct SurfaceTemperatureEquation <: JutulEquation
     # Equation:
     #        T_surf - T|top_cell = 0
+end
+
+struct SurfaceEnthalpyEquation <: JutulEquation
+    # Equation:
+    #        H_surf - H|top_cell = 0
 end
 
 Base.@kwdef struct BottomHolePressureEquation <: JutulEquation

--- a/src/facility/types.jl
+++ b/src/facility/types.jl
@@ -869,9 +869,10 @@ struct SurfaceTemperatureEquation <: JutulEquation
     #        T_surf - T|top_cell = 0
 end
 
-struct SurfaceEnthalpyEquation <: JutulEquation
+Base.@kwdef struct SurfaceEnthalpyEquation <: JutulEquation
     # Equation:
     #        H_surf - H|top_cell = 0
+    scale::Float64 = 1e-3
 end
 
 Base.@kwdef struct BottomHolePressureEquation <: JutulEquation

--- a/src/facility/types.jl
+++ b/src/facility/types.jl
@@ -676,7 +676,7 @@ function update_target!(ctrl, target::ReinjectionTarget, state_facility, state_w
 end
 
 """
-    InjectorControl(target, mix, density = 1.0, phases = ((1, 1.0)), temperature = 293.15)
+    InjectorControl(target, mix, density = 1.0, phases = ((1, 1.0)), temperature = 293.15, enthalpy = missing)
 
 Well control that specifies injection into the reservoir. `target` specifies the type of target and `mix` defines the
 injection mass fractions for all species in the model during injection. 
@@ -688,6 +688,11 @@ system (e.g. `LiquidPhase(), VaporPhase()`) the species corresponds to phases an
 
 The density of the injected fluid at surface conditions is given by `density` which is defaulted to 1.0
 if not given.
+
+`enthalpy` controls the injected specific enthalpy. Supported modes are:
+- `missing`: derive the injected enthalpy from the injector temperature and well state.
+- `::Real`: use a constant injected specific enthalpy.
+- `::Function`: use a callback `(p, T) -> h` evaluated at the well top node pressure and target temperature.
 
 See also [`ProducerControl`](@ref), [`DisabledControl`](@ref).
 """

--- a/src/facility/types.jl
+++ b/src/facility/types.jl
@@ -129,13 +129,13 @@ function Jutul.relative_increment_limit(q::TotalSurfaceMassRate)
     return q.max_relative_change
 end
 
-Base.@kwdef struct SurfaceTemperature <: ScalarVariable
+Base.@kwdef struct SurfaceTemperature{T} <: ScalarVariable
     "Maximum absolute change betweeen two Newton updates (nominally K)"
     max_absolute_change::Union{Float64, Nothing} = nothing
     "Maximum relative change between two Newton updates."
     max_relative_change::Union{Float64, Nothing} = nothing
-    min = 273.15
-    max = 1e6
+    min::T = 273.15
+    max::T = 1e6
 end
 
 function Jutul.absolute_increment_limit(T::SurfaceTemperature)
@@ -146,13 +146,13 @@ function Jutul.relative_increment_limit(T::SurfaceTemperature)
     return T.max_relative_change
 end
 
-Base.@kwdef struct SurfaceEnthalpy <: ScalarVariable
+Base.@kwdef struct SurfaceEnthalpy{T} <: ScalarVariable
     "Maximum absolute change betweeen two Newton updates (nominally J/kg)"
     max_absolute_change::Union{Float64, Nothing} = nothing
     "Maximum relative change between two Newton updates."
     max_relative_change::Union{Float64, Nothing} = nothing
-    min = 0.0
-    max = 1e12
+    min::T = 0.0
+    max::T = 1e12
 end
 
 function Jutul.absolute_increment_limit(H::SurfaceEnthalpy)

--- a/src/facility/wellgroups.jl
+++ b/src/facility/wellgroups.jl
@@ -136,7 +136,7 @@ end
 Jutul.associated_entity(::SurfaceTemperatureEquation) = Wells()
 Jutul.local_discretization(::SurfaceTemperatureEquation, i) = nothing
 function Jutul.update_equation_in_entity!(v, i, state, state0, eq::SurfaceTemperatureEquation, model, dt, ldisc = local_discretization(eq, i))
-    # Set equal to surface temperature. corresponding well temperatures will be
+    # Set equal to surface temperature. Corresponding well temperatures will be
     # subtracted using cross terms
     v[1] = state.SurfaceTemperature[i]
 end
@@ -144,7 +144,7 @@ end
 Jutul.associated_entity(::SurfaceEnthalpyEquation) = Wells()
 Jutul.local_discretization(::SurfaceEnthalpyEquation, i) = nothing
 function Jutul.update_equation_in_entity!(v, i, state, state0, eq::SurfaceEnthalpyEquation, model, dt, ldisc = local_discretization(eq, i))
-    # Set equal to surface enthalpy. corresponding well enthalpies will be
+    # Set equal to surface enthalpy. Corresponding well enthalpies will be
     # subtracted using cross terms
     v[1] = state.SurfaceEnthalpy[i]
 end
@@ -152,7 +152,7 @@ end
 Jutul.associated_entity(::BottomHolePressureEquation) = Wells()
 Jutul.local_discretization(::BottomHolePressureEquation, i) = nothing
 function Jutul.update_equation_in_entity!(v, i, state, state0, eq::BottomHolePressureEquation, model, dt, ldisc = local_discretization(eq, i))
-    # Set equal to bhp. corresponding well top cell pressures will be
+    # Set equal to bhp. Corresponding well top cell pressures will be
     # subtracted using cross terms
     v[1] = state.BottomHolePressure[i]*eq.scale
 end
@@ -162,8 +162,8 @@ Jutul.local_discretization(::SurfacePhaseRatesEquation, i) = nothing
 Jutul.number_of_equations_per_entity(fmodel::SimulationModel, eq::SurfacePhaseRatesEquation) = length(get_phases(fmodel.system))
 
 function Jutul.update_equation_in_entity!(v, i, state, state0, eq::SurfacePhaseRatesEquation, model, dt, ldisc = local_discretization(eq, i))
-    # Set equal to bhp. corresponding well top cell pressures will be
-    # subtracted using corss terms
+    # Set equal to bhp. Corresponding well top cell pressures will be
+    # subtracted using cross terms
     for ph in eachindex(v)
         v[ph] = state.SurfacePhaseRates[ph, i]*eq.scale
     end

--- a/src/facility/wellgroups.jl
+++ b/src/facility/wellgroups.jl
@@ -146,7 +146,7 @@ Jutul.local_discretization(::SurfaceEnthalpyEquation, i) = nothing
 function Jutul.update_equation_in_entity!(v, i, state, state0, eq::SurfaceEnthalpyEquation, model, dt, ldisc = local_discretization(eq, i))
     # Set equal to surface enthalpy. Corresponding well enthalpies will be
     # subtracted using cross terms
-    v[1] = state.SurfaceEnthalpy[i]
+    v[1] = state.SurfaceEnthalpy[i]*eq.scale
 end
 
 Jutul.associated_entity(::BottomHolePressureEquation) = Wells()

--- a/src/facility/wellgroups.jl
+++ b/src/facility/wellgroups.jl
@@ -14,6 +14,10 @@ function Jutul.associated_entity(::SurfaceTemperature)
     return Wells()
 end
 
+function Jutul.associated_entity(::SurfaceEnthalpy)
+    return Wells()
+end
+
 function Jutul.associated_entity(::TotalSurfaceMassRate)
     return Wells()
 end
@@ -135,6 +139,14 @@ function Jutul.update_equation_in_entity!(v, i, state, state0, eq::SurfaceTemper
     # Set equal to surface temperature. corresponding well temperatures will be
     # subtracted using cross terms
     v[1] = state.SurfaceTemperature[i]
+end
+
+Jutul.associated_entity(::SurfaceEnthalpyEquation) = Wells()
+Jutul.local_discretization(::SurfaceEnthalpyEquation, i) = nothing
+function Jutul.update_equation_in_entity!(v, i, state, state0, eq::SurfaceEnthalpyEquation, model, dt, ldisc = local_discretization(eq, i))
+    # Set equal to surface enthalpy. corresponding well enthalpies will be
+    # subtracted using cross terms
+    v[1] = state.SurfaceEnthalpy[i]
 end
 
 Jutul.associated_entity(::BottomHolePressureEquation) = Wells()

--- a/src/forces/bc.jl
+++ b/src/forces/bc.jl
@@ -5,6 +5,7 @@
     temperature = 298.15;
     fractional_flow = nothing,
     density = nothing,
+    enthalpy = nothing,
     trans_flow = 1e-12,
     trans_thermal = 1e-6
     )
@@ -323,6 +324,9 @@ function Jutul.vectorization_length(bc::FlowBoundaryCondition, model, name, vari
         if !isnothing(bc.density)
             n += 1
         end
+        if !isnothing(bc.enthalpy)
+            n += 1
+        end
         return n
     elseif variant == :control
         return 1
@@ -356,6 +360,11 @@ function Jutul.vectorize_force!(v, model::SimulationModel, bc::FlowBoundaryCondi
             v[offset] = bc.density
             push!(names, :density)
         end
+        if !isnothing(bc.enthalpy)
+            offset += 1
+            v[offset] = bc.enthalpy
+            push!(names, :enthalpy)
+        end
     elseif variant == :control
         v[1] = bc.pressure
         push!(names, :pressure)
@@ -380,13 +389,17 @@ function Jutul.devectorize_force(bc::FlowBoundaryCondition, model::SimulationMod
 
         offset = 4
         if !isnothing(f)
-            f = X[(offset+1):(offset+length(f))]
+            nf = length(f)
+            f = Tuple(X[(offset+1):(offset+nf)])
+            offset += nf
         end
         if !isnothing(ρ)
-            ρ = X[end-1]
+            offset += 1
+            ρ = X[offset]
         end
         if !isnothing(h)
-            h = X[end]
+            offset += 1
+            h = X[offset]
         end
     elseif variant == :control
         # DO nothing

--- a/src/forces/bc.jl
+++ b/src/forces/bc.jl
@@ -276,9 +276,8 @@ function compute_bc_heat_fluxes(system::JutulSystem, bc, gmap, state)
 
     # Get boundary properties
     T_h    = bc.trans_thermal
-    p_bc   = bc.pressure
     T_bc   = bc.temperature
-    rho_bc = bc.density
+    h_in   = bc_inflow_enthalpy(bc, state, c)
 
     qh_advective = 0
     for ph in 1:nph
@@ -286,16 +285,7 @@ function compute_bc_heat_fluxes(system::JutulSystem, bc, gmap, state)
             # Flow out from domain
             h_ph = h[ph,c]
         else
-            Cp = u[ph,c]/T[c]
-            if isnothing(rho_bc)
-                # Density not provided, take saturation average from what we
-                # have in the inside of the domain
-                rho_bc = 0.0
-                for ph in 1:nph
-                    rho_bc += state.Saturations[ph,c]*rho[ph,c]
-                end
-            end
-            h_ph = Cp*T_bc + p_bc/rho_bc
+            h_ph = h_in
         end
         qh_advective += h_ph*q[ph]
     end
@@ -304,6 +294,25 @@ function compute_bc_heat_fluxes(system::JutulSystem, bc, gmap, state)
     qh_conductive = T_h*ΔT
 
     return qh_advective, qh_conductive
+end
+
+function bc_inflow_enthalpy(bc, state, cell)
+    if !isnothing(bc.enthalpy)
+        return bc.enthalpy
+    elseif haskey(state, :Enthalpy)
+        return state.Enthalpy[cell]
+    end
+    H = state.FluidEnthalpy
+    if haskey(state, :Saturations)
+        S = state.Saturations
+        H_in = zero(H[1, cell])
+        for ph in axes(H, 1)
+            H_in += H[ph, cell]*S[ph, cell]
+        end
+    else
+        H_in = H[1, cell]
+    end
+    return H_in
 end
 
 function apply_flow_bc!(acc, q, bc, model::SimulationModel{<:Any, T}, state, time) where T<:Union{ImmiscibleSystem, SinglePhaseSystem}

--- a/src/forces/bc.jl
+++ b/src/forces/bc.jl
@@ -93,8 +93,10 @@ export flow_boundary_condition
 
 Add flow boundary conditions to a vector of `cells` for a given `domain` coming
 from `reservoir_domain`. The input arguments `pressures` and `temperatures` can
-either be scalars or one value per cell. Other keyword arguments are passed onto
-the `FlowBoundaryCondition` constructor.
+either be scalars or one value per cell. Optional injected-stream properties
+such as `fractional_flow`, `density`, and `enthalpy` can be provided through
+keyword arguments, which are passed onto the `FlowBoundaryCondition`
+constructor.
 
 The output of this function is a `Vector` of boundary conditions that can be
 passed on the form `forces = setup_reservoir_forces(model, bc = bc)`.

--- a/src/forces/bc.jl
+++ b/src/forces/bc.jl
@@ -154,7 +154,8 @@ function Jutul.subforce(s::AbstractVector{S}, model) where S<:FlowBoundaryCondit
             bc.trans_flow,
             bc.trans_thermal,
             bc.fractional_flow,
-            bc.density
+            bc.density,
+            bc.enthalpy
         )
     end
     return s[keep]
@@ -178,7 +179,7 @@ function Jutul.apply_forces_to_equation!(acc, storage, model::SimulationModel{D,
     for bc in force
         c = bc.cell
         acc_i = view(acc, :, c)
-        qh_adv, qh_cond = compute_bc_heat_fluxes(system, bc, global_map(model), state, nph)
+        qh_adv, qh_cond = compute_bc_heat_fluxes(system, bc, global_map(model), state)
         apply_flow_bc!(acc_i, qh_adv + qh_cond, bc, model, state, time)
     end
 end
@@ -367,6 +368,7 @@ function Jutul.devectorize_force(bc::FlowBoundaryCondition, model::SimulationMod
     trans_thermal = bc.trans_thermal
     f = bc.fractional_flow
     ρ = bc.density
+    h = bc.enthalpy
     if variant == :all
         T = X[2]
         trans_flow = X[3]
@@ -377,7 +379,10 @@ function Jutul.devectorize_force(bc::FlowBoundaryCondition, model::SimulationMod
             f = X[(offset+1):(offset+length(f))]
         end
         if !isnothing(ρ)
-            ρ = X[end]
+            ρ = X[end-1]
+        end
+        if !isnothing(h)
+            h = X[end]
         end
     elseif variant == :control
         # DO nothing
@@ -391,6 +396,7 @@ function Jutul.devectorize_force(bc::FlowBoundaryCondition, model::SimulationMod
         trans_flow,
         trans_thermal,
         f,
-        ρ
+        ρ,
+        h
     )
 end

--- a/src/forces/bc.jl
+++ b/src/forces/bc.jl
@@ -17,13 +17,14 @@ function FlowBoundaryCondition(
         temperature = 298.15;
         fractional_flow = nothing,
         density = nothing,
+        enthalpy = nothing,
         trans_flow = 1e-12,
         trans_thermal = 1e-6
     )
     pressure >= DEFAULT_MINIMUM_PRESSURE || throw(ArgumentError("Pressure must be at least $DEFAULT_MINIMUM_PRESSURE"))
     temperature >= 0.0 || throw(ArgumentError("Temperature must be at least 0.0 K"))
-
     isnothing(density) || density > 0.0 || error("Density, if provided, must be positive")
+    isnothing(enthalpy) || enthalpy >= 0.0 || error("Enthalpy, if provided, must be non-negative")
     if isnothing(fractional_flow)
         f = fractional_flow
     else
@@ -35,7 +36,7 @@ function FlowBoundaryCondition(
         sum(f) == 1.0 || error("Fractional flow for boundary condition in cell $cell must sum to 1.")
     end
     pressure, temperature, trans_flow, trans_thermal = promote(pressure, temperature, trans_flow, trans_thermal)
-    return FlowBoundaryCondition(cell, pressure, temperature, trans_flow, trans_thermal, f, density)
+    return FlowBoundaryCondition(cell, pressure, temperature, trans_flow, trans_thermal, f, density, enthalpy)
 end
 
 function FlowBoundaryCondition(
@@ -97,16 +98,16 @@ the `FlowBoundaryCondition` constructor.
 The output of this function is a `Vector` of boundary conditions that can be
 passed on the form `forces = setup_reservoir_forces(model, bc = bc)`.
 """
-function flow_boundary_condition(cells, domain, pressures, temperatures = 298.15; fractional_flow = nothing, kwarg...)
+function flow_boundary_condition(cells, domain, pressures, temperatures = 298.15; fractional_flow = nothing, enthalpy = nothing, kwarg...)
     if fractional_flow isa Vector
         fractional_flow = tuple(fractional_flow...)
     end
     bc = []
-    flow_boundary_condition!(bc, domain, cells, pressures, temperatures; fractional_flow = fractional_flow, kwarg...)
+    flow_boundary_condition!(bc, domain, cells, pressures, temperatures; fractional_flow = fractional_flow, enthalpy = enthalpy, kwarg...)
     return [i for i in bc]
 end
 
-function flow_boundary_condition!(bc, domain, cells, pressures, temperatures = 298.15; kwarg...)
+function flow_boundary_condition!(bc, domain, cells, pressures, temperatures = 298.15; enthalpy = nothing, kwarg...)
     n = length(cells)
     if temperatures isa Real
         temperatures = fill(temperatures, n)
@@ -114,11 +115,15 @@ function flow_boundary_condition!(bc, domain, cells, pressures, temperatures = 2
     if pressures isa Real
         pressures = fill(pressures, n)
     end
+    if enthalpy isa Real || isnothing(enthalpy)
+        enthalpy = fill(enthalpy, n)
+    end
     length(temperatures) == n || throw(ArgumentError("Mismatch in length of cells and temperatures arrays"))
     length(pressures) == n || throw(ArgumentError("Mismatch in length of cells and pressures arrays"))
+    length(enthalpy) == n || throw(ArgumentError("Mismatch in length of cells and enthalpy arrays"))
 
-    for (cell, pressure, temperature) in zip(cells, pressures, temperatures)
-        bc_c = FlowBoundaryCondition(domain, cell, pressure, temperature; kwarg...)
+    for (cell, pressure, temperature, h) in zip(cells, pressures, temperatures, enthalpy)
+        bc_c = FlowBoundaryCondition(domain, cell, pressure, temperature; enthalpy = h, kwarg...)
         push!(bc, bc_c)
     end
 
@@ -157,28 +162,30 @@ end
 
 function Jutul.apply_forces_to_equation!(acc, storage, model::SimulationModel{D, S}, eq::ConservationLaw{:TotalMasses}, eq_s, force::V, time) where {V <: AbstractVector{<:FlowBoundaryCondition}, D, S<:MultiPhaseSystem}
     state = storage.state
-    nph = number_of_phases(reservoir_model(model).system)
+    system = reservoir_model(model).system
     for bc in force
         c = bc.cell
         acc_i = view(acc, :, c)
-        q = compute_bc_mass_fluxes(bc, global_map(model), state, nph)
+        q = compute_bc_mass_fluxes(system, bc, global_map(model), state)
         apply_flow_bc!(acc_i, q, bc, model, state, time)
     end
 end
 
 function Jutul.apply_forces_to_equation!(acc, storage, model::SimulationModel{D, S}, eq::ConservationLaw{:TotalThermalEnergy}, eq_s, force::V, time) where {V <: AbstractVector{<:FlowBoundaryCondition}, D, S<:MultiPhaseSystem}
     state = storage.state
-    nph = number_of_phases(reservoir_model(model).system)
+    system = reservoir_model(model).system
+    nph = number_of_phases(system)
     for bc in force
         c = bc.cell
         acc_i = view(acc, :, c)
-        qh_adv, qh_cond = compute_bc_heat_fluxes(bc, global_map(model), state, nph)
+        qh_adv, qh_cond = compute_bc_heat_fluxes(system, bc, global_map(model), state, nph)
         apply_flow_bc!(acc_i, qh_adv + qh_cond, bc, model, state, time)
     end
 end
 
-function compute_bc_mass_fluxes(bc, gmap, state, nph)
+function compute_bc_mass_fluxes(system::JutulSystem, bc, gmap, state)
     # Get reservoir properties
+    nph = number_of_phases(system)
     p   = state.Pressure
     mu  = state.PhaseViscosities
     kr  = state.RelativePermeabilities
@@ -248,8 +255,9 @@ function compute_bc_mass_fluxes(bc, gmap, state, nph)
     return q
 end
 
-function compute_bc_heat_fluxes(bc, gmap, state, nph)
-    q = compute_bc_mass_fluxes(bc, gmap, state, nph)
+function compute_bc_heat_fluxes(system::JutulSystem, bc, gmap, state)
+    nph = number_of_phases(system)
+    q = compute_bc_mass_fluxes(system, bc, gmap, state)
     c = Jutul.full_cell(bc.cell, gmap)
 
     # Get reservoir properties

--- a/src/forces/bc.jl
+++ b/src/forces/bc.jl
@@ -107,7 +107,7 @@ function flow_boundary_condition(cells, domain, pressures, temperatures = 298.15
     return [i for i in bc]
 end
 
-function flow_boundary_condition!(bc, domain, cells, pressures, temperatures = 298.15; enthalpy = nothing, kwarg...)
+function flow_boundary_condition!(bc, domain, cells, pressures, temperatures = 298.15; density = nothing, enthalpy = nothing, kwarg...)
     n = length(cells)
     if temperatures isa Real
         temperatures = fill(temperatures, n)
@@ -115,15 +115,19 @@ function flow_boundary_condition!(bc, domain, cells, pressures, temperatures = 2
     if pressures isa Real
         pressures = fill(pressures, n)
     end
+    if density isa Real || isnothing(density)
+        density = fill(density, n)
+    end
     if enthalpy isa Real || isnothing(enthalpy)
         enthalpy = fill(enthalpy, n)
     end
     length(temperatures) == n || throw(ArgumentError("Mismatch in length of cells and temperatures arrays"))
     length(pressures) == n || throw(ArgumentError("Mismatch in length of cells and pressures arrays"))
     length(enthalpy) == n || throw(ArgumentError("Mismatch in length of cells and enthalpy arrays"))
+    length(density) == n || throw(ArgumentError("Mismatch in length of cells and density arrays"))
 
-    for (cell, pressure, temperature, h) in zip(cells, pressures, temperatures, enthalpy)
-        bc_c = FlowBoundaryCondition(domain, cell, pressure, temperature; enthalpy = h, kwarg...)
+    for (cell, pressure, temperature, h, ρ) in zip(cells, pressures, temperatures, enthalpy, density)
+        bc_c = FlowBoundaryCondition(domain, cell, pressure, temperature; density = ρ, enthalpy = h, kwarg...)
         push!(bc, bc_c)
     end
 

--- a/src/multicomponent/bc.jl
+++ b/src/multicomponent/bc.jl
@@ -82,13 +82,12 @@ function compute_bc_heat_fluxes(system::AbstractCompositionalSystemLV, bc, gmap,
 
     # Get reservoir properties
     h_ph = state.FluidEnthalpy
-    h = state.Enthalpy
 
     q_adv = 0.0
     if size(q, 1) == 1
         q_tot = sum(q)
         @assert q_tot <= 0.0
-        q_adv = q_tot*bc.enthalpy
+        q_adv = q_tot*bc_inflow_enthalpy(bc, state, c)
     else
         @assert size(q, 1) == nph
         for ph in 1:nph
@@ -105,6 +104,25 @@ function compute_bc_heat_fluxes(system::AbstractCompositionalSystemLV, bc, gmap,
 
     return q_adv, qh_cond
 
+end
+
+function bc_inflow_enthalpy(bc, state, cell)
+    if !isnothing(bc.enthalpy)
+        return bc.enthalpy
+    elseif haskey(state, :Enthalpy)
+        return state.Enthalpy[cell]
+    end
+    H = state.FluidEnthalpy
+    if haskey(state, :Saturations)
+        S = state.Saturations
+        H_in = zero(H[1, cell])
+        for ph in axes(H, 1)
+            H_in += H[ph, cell]*S[ph, cell]
+        end
+    else
+        H_in = H[1, cell]
+    end
+    return H_in
 end
 
 function apply_flow_bc!(acc, q, bc, model::SimulationModel{<:Any, T}, state, time) where T<:AbstractCompositionalSystemLV

--- a/src/multicomponent/bc.jl
+++ b/src/multicomponent/bc.jl
@@ -1,14 +1,3 @@
-# function Jutul.apply_forces_to_equation!(acc, storage, model::SimulationModel{<:Any, T}, eq::ConservationLaw{:TotalMasses}, eq_s, force::V, time) where {T<:AbstractCompositionalSystemLV, V <: AbstractVector{<:FlowBoundaryCondition}}
-#     state = storage.state
-#     p = state.Pressure
-#     for bc in force
-#         c = bc.cell
-#         acc_i = view(acc, :, c)
-#         q = compute_bc_mass_fluxes(model.system, bc, global_map(model), state)
-#         apply_flow_bc!(acc_i, q, bc, model, state, time)
-#     end
-# end
-
 function compute_bc_mass_fluxes(system::AbstractCompositionalSystemLV, bc, gmap, state)
     c = bc.cell
     T_f = bc.trans_flow
@@ -85,7 +74,7 @@ function compute_bc_mass_fluxes(system::AbstractCompositionalSystemLV, bc, gmap,
 
 end
 
-function compute_bc_heat_fluxes(system::AbstractCompositionalSystemLV, bc, gmap, state, nph)
+function compute_bc_heat_fluxes(system::AbstractCompositionalSystemLV, bc, gmap, state)
 
     nph = number_of_phases(system)
     q = compute_bc_mass_fluxes(system, bc, gmap, state)
@@ -126,140 +115,4 @@ function apply_flow_bc!(acc, q, bc, model::SimulationModel{<:Any, T}, state, tim
         acc[i] += sum(q[:, i])
     end
 
-end
-
-function apply_flow_bc!(acc, q, bc, model::SimulationModel{<:Any, T}, state, time) where T<:AbstractCompositionalSystemLV
-    mob = state.PhaseMobilities
-    rho = state.PhaseMassDensities
-    ncomp = length(acc)
-    nph = size(rho, 1)
-
-    rho_inj = bc.density
-    f_inj = bc.fractional_flow
-    c = bc.cell
-    # TODO: Capillary pressure.
-    if q > 0
-        X = state.LiquidMassFractions
-        Y = state.VaporMassFractions
-        # Pressure inside is higher than outside, flow out from domain
-        sys = model.system
-        phase_ix = phase_indices(sys)
-        if has_other_phase(sys)
-            a, l, v = phase_ix
-            ncomp_mix = ncomp-1
-            acc[ncomp_mix+1] += rho[a, c]*mob[a, c]*q
-        else
-            ncomp_mix = ncomp
-            l, v = phase_ix
-        end
-        q_l = rho[l, c]*mob[l, c]*q
-        q_v = rho[v, c]*mob[v, c]*q
-        for i in 1:ncomp_mix
-            acc[i] += q_l*X[i, c] + q_v*Y[i, c]
-        end
-    else
-        # TODO: This is duplicated code, factor out...
-        # Injection of mass
-        λ_t = 0.0
-        for ph in 1:nph
-            λ_t += mob[ph, c]
-        end
-        if isnothing(rho_inj)
-            # Density not provided, take saturation average from what we have in
-            # the inside of the domain
-            rho_inj = 0.0
-            for ph in 1:nph
-                rho_inj += state.Saturations[ph, c]*rho[ph, c]
-            end
-        end
-        if isnothing(f_inj)
-            # Fractional flow not provided. We match the mass fraction we
-            # observe on the inside.
-            total = 0.0
-            for i in 1:ncomp
-                total += state.TotalMasses[i, c]
-            end
-            for i in 1:ncomp
-                F = state.TotalMasses[i, c]/total
-                acc[i] += q*rho_inj*λ_t*F
-            end
-        else
-            @assert length(f_inj) == ncomp
-            for i in 1:ncomp
-                F = f_inj[i]
-                acc[i] += q*rho_inj*λ_t*F
-            end
-        end
-    end
-end
-
-function compute_bc_heat_fluxes(bc, system, gmap, state)
-
-    # function apply_flow_bc!(acc, q, bc, model::SimulationModel{<:Any, T}, state, time) where T<:AbstractCompositionalSystemLV
-    mob = state.PhaseMobilities
-    rho = state.PhaseMassDensities
-    h_ph = state.FluidEnthalpy
-    h = state.Enthalpy
-    ncomp = number_of_components(system)
-    nph = size(rho, 1)
-
-    rho_inj = bc.density
-    f_inj = bc.fractional_flow
-    c = bc.cell
-    # TODO: Capillary pressure.
-    if q > 0
-        X = state.LiquidMassFractions
-        Y = state.VaporMassFractions
-        # Pressure inside is higher than outside, flow out from domain
-        sys = model.system
-        phase_ix = phase_indices(sys)
-        if has_other_phase(sys)
-            a, l, v = phase_ix
-            ncomp_mix = ncomp-1
-            acc[ncomp_mix+1] += rho[a, c]*mob[a, c]*q
-        else
-            ncomp_mix = ncomp
-            l, v = phase_ix
-        end
-        q_l = rho[l, c]*mob[l, c]*q
-        q_v = rho[v, c]*mob[v, c]*q
-        q_adv = q_l*h_ph[l, c] + q_v*h_ph[v, c]
-        # for i in 1:ncomp_mix
-        #     acc[i] += h_ph[l, c]*q_l*X[i, c] + h_ph[v, c]*q_v*Y[i, c]
-        # end
-    else
-        # TODO: This is duplicated code, factor out...
-        # Injection of mass
-        λ_t = 0.0
-        for ph in 1:nph
-            λ_t += mob[ph, c]
-        end
-        if isnothing(rho_inj)
-            # Density not provided, take saturation average from what we have in
-            # the inside of the domain
-            rho_inj = 0.0
-            for ph in 1:nph
-                rho_inj += state.Saturations[ph, c]*rho[ph, c]
-            end
-        end
-        if isnothing(f_inj)
-            # Fractional flow not provided. We match the mass fraction we
-            # observe on the inside.
-            total = 0.0
-            for i in 1:ncomp
-                total += state.TotalMasses[i, c]
-            end
-
-            for i in 1:ncomp
-                F = state.TotalMasses[i, c]/total
-                acc[i] += h[c]q*rho_inj*λ_t*F
-            end
-        else
-            @assert length(f_inj) == ncomp
-            for i in 1:ncomp
-                F = f_inj[i]
-                acc[i] += h[c]*q*rho_inj*λ_t*F
-            end
-        end
-    end
 end

--- a/src/multicomponent/bc.jl
+++ b/src/multicomponent/bc.jl
@@ -1,4 +1,4 @@
-function compute_bc_mass_fluxes(system::AbstractCompositionalSystemLV, bc, gmap, state)
+function compute_bc_mass_fluxes(system::CompositionalSystemLV, bc, gmap, state)
     c = bc.cell
     T_f = bc.trans_flow
     p = state.Pressure
@@ -74,7 +74,7 @@ function compute_bc_mass_fluxes(system::AbstractCompositionalSystemLV, bc, gmap,
 
 end
 
-function compute_bc_heat_fluxes(system::AbstractCompositionalSystemLV, bc, gmap, state)
+function compute_bc_heat_fluxes(system::CompositionalSystemLV, bc, gmap, state)
 
     nph = number_of_phases(system)
     q = compute_bc_mass_fluxes(system, bc, gmap, state)
@@ -106,7 +106,7 @@ function compute_bc_heat_fluxes(system::AbstractCompositionalSystemLV, bc, gmap,
 
 end
 
-function apply_flow_bc!(acc, q, bc, model::SimulationModel{<:Any, T}, state, time) where T<:AbstractCompositionalSystemLV
+function apply_flow_bc!(acc, q, bc, model::SimulationModel{<:Any, T}, state, time) where T<:CompositionalSystemLV
 
     system = reservoir_model(model).system
     ncomp = number_of_components(system)

--- a/src/multicomponent/bc.jl
+++ b/src/multicomponent/bc.jl
@@ -106,25 +106,6 @@ function compute_bc_heat_fluxes(system::AbstractCompositionalSystemLV, bc, gmap,
 
 end
 
-function bc_inflow_enthalpy(bc, state, cell)
-    if !isnothing(bc.enthalpy)
-        return bc.enthalpy
-    elseif haskey(state, :Enthalpy)
-        return state.Enthalpy[cell]
-    end
-    H = state.FluidEnthalpy
-    if haskey(state, :Saturations)
-        S = state.Saturations
-        H_in = zero(H[1, cell])
-        for ph in axes(H, 1)
-            H_in += H[ph, cell]*S[ph, cell]
-        end
-    else
-        H_in = H[1, cell]
-    end
-    return H_in
-end
-
 function apply_flow_bc!(acc, q, bc, model::SimulationModel{<:Any, T}, state, time) where T<:AbstractCompositionalSystemLV
 
     system = reservoir_model(model).system

--- a/src/multicomponent/bc.jl
+++ b/src/multicomponent/bc.jl
@@ -1,18 +1,134 @@
-function Jutul.apply_forces_to_equation!(acc, storage, model::SimulationModel{<:Any, T}, eq::ConservationLaw{:TotalMasses}, eq_s, force::V, time) where {T<:MultiPhaseCompositionalSystemLV, V <: AbstractVector{<:FlowBoundaryCondition}}
-    state = storage.state
+# function Jutul.apply_forces_to_equation!(acc, storage, model::SimulationModel{<:Any, T}, eq::ConservationLaw{:TotalMasses}, eq_s, force::V, time) where {T<:AbstractCompositionalSystemLV, V <: AbstractVector{<:FlowBoundaryCondition}}
+#     state = storage.state
+#     p = state.Pressure
+#     for bc in force
+#         c = bc.cell
+#         acc_i = view(acc, :, c)
+#         q = compute_bc_mass_fluxes(model.system, bc, global_map(model), state)
+#         apply_flow_bc!(acc_i, q, bc, model, state, time)
+#     end
+# end
+
+function compute_bc_mass_fluxes(system::AbstractCompositionalSystemLV, bc, gmap, state)
+    c = bc.cell
+    T_f = bc.trans_flow
     p = state.Pressure
-    for bc in force
-        c = bc.cell
-        acc_i = view(acc, :, c)
-        T_f = bc.trans_flow
-        Δp = p[c] - bc.pressure
-        q = T_f*Δp
-        apply_flow_bc!(acc_i, q, bc, model, state, time)
+    Δp = p[c] - bc.pressure
+    q_vol = T_f*Δp
+
+    mob = state.PhaseMobilities
+    rho = state.PhaseMassDensities
+    ncomp = number_of_components(system)
+    nph = number_of_phases(system)
+
+    rho_inj = bc.density
+    f_inj = bc.fractional_flow
+    c = bc.cell
+    # TODO: Capillary pressure.
+    T = Base.promote_type(typeof(q_vol), eltype(rho), eltype(mob))
+    if q_vol > 0
+        q = zeros(T, nph, ncomp)
+        X = state.LiquidMassFractions
+        Y = state.VaporMassFractions
+        # Pressure inside is higher than outside, flow out from domain
+        phase_ix = phase_indices(system)
+        if has_other_phase(system)
+            a, l, v = phase_ix
+            ncomp_mix = ncomp-1
+            q[a, ncomp_mix+1] = rho[a, c]*mob[a, c]*q_vol
+        else
+            ncomp_mix = ncomp
+            l, v = phase_ix
+        end
+        q_l = rho[l, c]*mob[l, c]*q_vol
+        q_v = rho[v, c]*mob[v, c]*q_vol
+        for i in 1:ncomp_mix
+            q[l, i] = q_l*X[i, c]
+            q[v, i] = q_v*Y[i, c]
+        end
+    else
+        q = zeros(T, 1, ncomp)
+        # TODO: This is duplicated code, factor out...
+        # Injection of mass
+        λ_t = 0.0
+        for ph in 1:nph
+            λ_t += mob[ph, c]
+        end
+        if isnothing(rho_inj)
+            # Density not provided, take saturation average from what we have in
+            # the inside of the domain
+            rho_inj = 0.0
+            for ph in 1:nph
+                rho_inj += state.Saturations[ph, c]*rho[ph, c]
+            end
+        end
+        if isnothing(f_inj)
+            # Fractional flow not provided. We match the mass fraction we
+            # observe on the inside.
+            total = 0.0
+            for i in 1:ncomp
+                total += state.TotalMasses[i, c]
+            end
+            for i in 1:ncomp
+                F = state.TotalMasses[i, c]/total
+                q[i] = q_vol*rho_inj*λ_t*F
+            end
+        else
+            @assert length(f_inj) == ncomp
+            for i in 1:ncomp
+                F = f_inj[i]
+                q[i] = q_vol*rho_inj*λ_t*F
+            end
+        end
     end
+    return q
+
 end
 
+function compute_bc_heat_fluxes(system::AbstractCompositionalSystemLV, bc, gmap, state, nph)
 
-function apply_flow_bc!(acc, q, bc, model::SimulationModel{<:Any, T}, state, time) where T<:MultiPhaseCompositionalSystemLV
+    nph = number_of_phases(system)
+    q = compute_bc_mass_fluxes(system, bc, gmap, state)
+    c = Jutul.full_cell(bc.cell, gmap)
+
+    # Get reservoir properties
+    h_ph = state.FluidEnthalpy
+    h = state.Enthalpy
+
+    q_adv = 0.0
+    if size(q, 1) == 1
+        q_tot = sum(q)
+        @assert q_tot <= 0.0
+        q_adv = q_tot*bc.enthalpy
+    else
+        @assert size(q, 1) == nph
+        for ph in 1:nph
+            q_ph = sum(q[ph, :])
+            q_adv += q_ph*h_ph[ph, c]
+        end
+    end
+
+    T_h    = bc.trans_thermal
+    T      = state.Temperature
+    T_bc   = bc.temperature
+    ΔT = T[c] - T_bc
+    qh_cond = T_h*ΔT
+
+    return q_adv, qh_cond
+
+end
+
+function apply_flow_bc!(acc, q, bc, model::SimulationModel{<:Any, T}, state, time) where T<:AbstractCompositionalSystemLV
+
+    system = reservoir_model(model).system
+    ncomp = number_of_components(system)
+    for i in 1:ncomp
+        acc[i] += sum(q[:, i])
+    end
+
+end
+
+function apply_flow_bc!(acc, q, bc, model::SimulationModel{<:Any, T}, state, time) where T<:AbstractCompositionalSystemLV
     mob = state.PhaseMobilities
     rho = state.PhaseMassDensities
     ncomp = length(acc)
@@ -77,3 +193,73 @@ function apply_flow_bc!(acc, q, bc, model::SimulationModel{<:Any, T}, state, tim
     end
 end
 
+function compute_bc_heat_fluxes(bc, system, gmap, state)
+
+    # function apply_flow_bc!(acc, q, bc, model::SimulationModel{<:Any, T}, state, time) where T<:AbstractCompositionalSystemLV
+    mob = state.PhaseMobilities
+    rho = state.PhaseMassDensities
+    h_ph = state.FluidEnthalpy
+    h = state.Enthalpy
+    ncomp = number_of_components(system)
+    nph = size(rho, 1)
+
+    rho_inj = bc.density
+    f_inj = bc.fractional_flow
+    c = bc.cell
+    # TODO: Capillary pressure.
+    if q > 0
+        X = state.LiquidMassFractions
+        Y = state.VaporMassFractions
+        # Pressure inside is higher than outside, flow out from domain
+        sys = model.system
+        phase_ix = phase_indices(sys)
+        if has_other_phase(sys)
+            a, l, v = phase_ix
+            ncomp_mix = ncomp-1
+            acc[ncomp_mix+1] += rho[a, c]*mob[a, c]*q
+        else
+            ncomp_mix = ncomp
+            l, v = phase_ix
+        end
+        q_l = rho[l, c]*mob[l, c]*q
+        q_v = rho[v, c]*mob[v, c]*q
+        q_adv = q_l*h_ph[l, c] + q_v*h_ph[v, c]
+        # for i in 1:ncomp_mix
+        #     acc[i] += h_ph[l, c]*q_l*X[i, c] + h_ph[v, c]*q_v*Y[i, c]
+        # end
+    else
+        # TODO: This is duplicated code, factor out...
+        # Injection of mass
+        λ_t = 0.0
+        for ph in 1:nph
+            λ_t += mob[ph, c]
+        end
+        if isnothing(rho_inj)
+            # Density not provided, take saturation average from what we have in
+            # the inside of the domain
+            rho_inj = 0.0
+            for ph in 1:nph
+                rho_inj += state.Saturations[ph, c]*rho[ph, c]
+            end
+        end
+        if isnothing(f_inj)
+            # Fractional flow not provided. We match the mass fraction we
+            # observe on the inside.
+            total = 0.0
+            for i in 1:ncomp
+                total += state.TotalMasses[i, c]
+            end
+
+            for i in 1:ncomp
+                F = state.TotalMasses[i, c]/total
+                acc[i] += h[c]q*rho_inj*λ_t*F
+            end
+        else
+            @assert length(f_inj) == ncomp
+            for i in 1:ncomp
+                F = f_inj[i]
+                acc[i] += h[c]*q*rho_inj*λ_t*F
+            end
+        end
+    end
+end

--- a/src/multicomponent/bc.jl
+++ b/src/multicomponent/bc.jl
@@ -111,8 +111,12 @@ function apply_flow_bc!(acc, q, bc, model::SimulationModel{<:Any, T}, state, tim
 
     system = reservoir_model(model).system
     ncomp = number_of_components(system)
-    for i in 1:ncomp
-        acc[i] += sum(q[:, i])
+    if ncomp == 1
+        acc[] += sum(q)
+    else
+        for i in 1:ncomp
+            acc[i] += sum(q[:, i])
+        end
     end
 
 end

--- a/src/state0.jl
+++ b/src/state0.jl
@@ -269,7 +269,7 @@ function setup_reservoir_state(model::MultiModel, equil::Union{Missing, Vector, 
     perf_subset(v::AbstractVector, i) = v[i]
     perf_subset(v::AbstractMatrix, i) = v[:, i]
     perf_subset(v, i) = v
-    is_thermal = model_is_thermal(rmodel)
+    is_thermal, th_var = model_is_thermal(rmodel, true)
     for k in keys(model.models)
         if k == :Reservoir
             # Already done
@@ -305,7 +305,7 @@ function setup_reservoir_state(model::MultiModel, equil::Union{Missing, Vector, 
     for (k, W) in get_model_wells(model)
         T = promote_type(T, eltype(init[k][:Pressure]))
         if is_thermal
-            T = promote_type(T, eltype(init[k][:Temperature]))
+            T = promote_type(T, eltype(init[k][th_var]))
         end
     end
 
@@ -321,7 +321,7 @@ function setup_reservoir_state(model::MultiModel, equil::Union{Missing, Vector, 
             for (i, w) in enumerate(own_wells)
                 bh[i] = init[w][:Pressure][1]
                 if is_thermal
-                    temp[i] = init[w][:Temperature][1]
+                    temp[i] = init[w][th_var][1]
                 end
             end
             init_arg[:BottomHolePressure] = bh

--- a/src/state0.jl
+++ b/src/state0.jl
@@ -266,6 +266,7 @@ function setup_reservoir_state(model::MultiModel, equil::Union{Missing, Vector, 
     res_state = setup_reservoir_state(rmodel, equil; kwarg...)
     # Next, we initialize the wells.
     init = Dict(:Reservoir => res_state)
+    well_cells = Dict{Symbol, Any}()
     perf_subset(v::AbstractVector, i) = v[i]
     perf_subset(v::AbstractMatrix, i) = v[:, i]
     perf_subset(v, i) = v
@@ -294,6 +295,7 @@ function setup_reservoir_state(model::MultiModel, equil::Union{Missing, Vector, 
                 init_w[:TotalMassFlux] = 0.0
             end
             c = map_well_nodes_to_reservoir_cells(wg, rmodel.data_domain)
+            well_cells[k] = c
             for pk in pvars
                 pv = res_state[pk]
                 init_w[pk] = perf_subset(pv, c)
@@ -318,15 +320,43 @@ function setup_reservoir_state(model::MultiModel, equil::Union{Missing, Vector, 
             own_wells = W.domain.well_symbols
             bh = zeros(T, length(own_wells))
             temp = similar(bh)
+            enth = similar(bh)
             for (i, w) in enumerate(own_wells)
+                wc = well_cells[w][1]
                 bh[i] = init[w][:Pressure][1]
                 if is_thermal
-                    temp[i] = init[w][th_var][1]
+                    if haskey(res_state, :Temperature)
+                        temp[i] = res_state[:Temperature][wc]
+                    else
+                        @error "Temperature variable not found in reservoir \
+                        state, but model is thermal. Cannot initialize \
+                        surface temperature for well $w."
+                    end
+                    if haskey(res_state, :Enthalpy)
+                        enth[i] = res_state[:Enthalpy][wc]
+                    elseif haskey(res_state, :FluidEnthalpy)
+                        H = res_state[:FluidEnthalpy]
+                        if haskey(res_state, :Saturations)
+                            S = res_state[:Saturations]
+                            enth_i = zero(H[1, wc])
+                            for ph in axes(H, 1)
+                                enth_i += H[ph, wc]*S[ph, wc]
+                            end
+                            enth[i] = enth_i
+                        else
+                            enth[i] = H[1, wc]
+                        end
+                    else
+                        @error "Enthalpy/FluidEnthalpy variable not found in \
+                        reservoir state, but model is thermal. Cannot \
+                        initialize surface enthalpy for well $w."
+                    end
                 end
             end
             init_arg[:BottomHolePressure] = bh
             if is_thermal
                 init_arg[:SurfaceTemperature] = temp
+                init_arg[:SurfaceEnthalpy] = enth
             end
             init[k] = setup_state(W; pairs(init_arg)...)
         end

--- a/src/thermal/thermal.jl
+++ b/src/thermal/thermal.jl
@@ -466,10 +466,15 @@ function add_thermal_to_model!(model)
 end
 
 function add_thermal_to_facility!(facility)
-    set_primary_variables!(facility, SurfaceTemperature = SurfaceTemperature())
+    set_primary_variables!(facility,
+        SurfaceTemperature = SurfaceTemperature(),
+        SurfaceEnthalpy = SurfaceEnthalpy()
+    )
     facility.equations[:temperature_equation] = SurfaceTemperatureEquation()
+    facility.equations[:enthalpy_equation] = SurfaceEnthalpyEquation()
     out = facility.output_variables
     push!(out, :SurfaceTemperature)
+    push!(out, :SurfaceEnthalpy)
     unique!(out)
     return facility
 end

--- a/src/thermal/thermal.jl
+++ b/src/thermal/thermal.jl
@@ -484,9 +484,22 @@ function model_is_thermal(model::MultiModel)
     return model_is_thermal(m)
 end
 
-function model_is_thermal(model::SimulationModel)
+function model_is_thermal(model::SimulationModel, return_name=false)
     pvars = Jutul.get_primary_variables(model)
-    return haskey(pvars, :Temperature)
+    candidates = [:Temperature, :Enthalpy]
+    is_thermal, name = false, nothing
+    for var in candidates
+        if haskey(pvars, var)
+            is_thermal = true
+            name = var
+            break
+        end
+    end
+    if return_name
+        return is_thermal, name
+    else
+        return is_thermal
+    end
 end
 
 include("variables.jl")

--- a/src/types.jl
+++ b/src/types.jl
@@ -394,6 +394,7 @@ struct FlowBoundaryCondition{I, F, T} <: JutulForce
     trans_thermal::F
     fractional_flow::T
     density::Union{F, Nothing}
+    enthalpy::Union{F, Nothing}
 end
 
 abstract type PorousMediumDomain <: JutulMesh end

--- a/src/types.jl
+++ b/src/types.jl
@@ -386,6 +386,17 @@ struct SourceTerm{I, F, T} <: JutulForce
     type::FlowSourceType
 end
 
+"""
+    FlowBoundaryCondition
+
+Boundary condition for prescribed pressure/temperature flow across a reservoir
+boundary. Optional `fractional_flow`, `density`, and `enthalpy` values can be
+used to specify the injected stream.
+
+If `enthalpy` is left as `nothing`, thermal compositional inflow falls back to
+the local reservoir-state enthalpy at the boundary cell: `Enthalpy` when
+available, otherwise a saturation-weighted value from `FluidEnthalpy`.
+"""
 struct FlowBoundaryCondition{I, F, T} <: JutulForce
     cell::I
     pressure::F

--- a/src/types.jl
+++ b/src/types.jl
@@ -19,7 +19,8 @@ abstract type BlackOilSystem <: MultiComponentSystem end
 abstract type PhaseVariables <: VectorVariables end
 abstract type ComponentVariables <: VectorVariables end
 
-struct MultiPhaseCompositionalSystemLV{E, T, O, R, N} <: CompositionalSystem where T<:Tuple
+abstract type AbstractCompositionalSystemLV <: CompositionalSystem end
+struct MultiPhaseCompositionalSystemLV{E, T, O, R, N} <: AbstractCompositionalSystemLV where T<:Tuple
     phases::T
     components::Vector{String}
     equation_of_state::E

--- a/src/types.jl
+++ b/src/types.jl
@@ -393,7 +393,7 @@ Boundary condition for prescribed pressure/temperature flow across a reservoir
 boundary. Optional `fractional_flow`, `density`, and `enthalpy` values can be
 used to specify the injected stream.
 
-If `enthalpy` is left as `nothing`, thermal compositional inflow falls back to
+If `enthalpy` is left as `nothing`, thermal inflow falls back to
 the local reservoir-state enthalpy at the boundary cell: `Enthalpy` when
 available, otherwise a saturation-weighted value from `FluidEnthalpy`.
 """

--- a/src/types.jl
+++ b/src/types.jl
@@ -19,8 +19,8 @@ abstract type BlackOilSystem <: MultiComponentSystem end
 abstract type PhaseVariables <: VectorVariables end
 abstract type ComponentVariables <: VectorVariables end
 
-abstract type AbstractCompositionalSystemLV <: CompositionalSystem end
-struct MultiPhaseCompositionalSystemLV{E, T, O, R, N} <: AbstractCompositionalSystemLV where T<:Tuple
+abstract type CompositionalSystemLV <: CompositionalSystem end
+struct MultiPhaseCompositionalSystemLV{E, T, O, R, N} <: CompositionalSystemLV where T<:Tuple
     phases::T
     components::Vector{String}
     equation_of_state::E

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -1329,10 +1329,11 @@ function simulate_reservoir(case::JutulCase;
     return ReservoirSimResult(model, result, forces; simulator = sim, config = config, start_date = case.start_date)
 end
 
-function system_uses_cnv_mb(system::JutulSystem)
-    systems = (SinglePhaseSystem, ImmiscibleSystem, BlackOilSystem, CompositionalSystem)
-    return any(s -> system isa s, systems)
-end
+system_uses_cnv_mb(system::JutulSystem) = false
+system_uses_cnv_mb(system::SinglePhaseSystem) = true
+system_uses_cnv_mb(system::ImmiscibleSystem) = true
+system_uses_cnv_mb(system::BlackOilSystem) = true
+system_uses_cnv_mb(system::CompositionalSystem) = true
 
 function set_default_cnv_mb!(cfg::JutulConfig, sim::JutulSimulator; kwarg...)
     set_default_cnv_mb!(cfg, sim.model; kwarg...)

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -1329,6 +1329,11 @@ function simulate_reservoir(case::JutulCase;
     return ReservoirSimResult(model, result, forces; simulator = sim, config = config, start_date = case.start_date)
 end
 
+function system_uses_cnv_mb(system::JutulSystem)
+    systems = (SinglePhaseSystem, ImmiscibleSystem, BlackOilSystem, CompositionalSystem)
+    return any(s -> system isa s, systems)
+end
+
 function set_default_cnv_mb!(cfg::JutulConfig, sim::JutulSimulator; kwarg...)
     set_default_cnv_mb!(cfg, sim.model; kwarg...)
 end
@@ -1374,8 +1379,7 @@ function set_default_cnv_mb_inner!(tol, model;
         end
     end
     sys = model.system
-    if sys isa SinglePhaseSystem || sys isa ImmiscibleSystem || 
-        sys isa BlackOilSystem || sys isa CompositionalSystem
+    if system_uses_cnv_mb(sys)
         is_well = model_or_domain_is_well(model)
         if is_well
             if physical_representation(model) isa SimpleWell

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -1450,6 +1450,8 @@ function setup_reservoir_cross_terms!(model::MultiModel)
                     add_cross_term!(model, ct, target = target_well, source = k, equation = energy)
                     ct = FacilityFromWellTemperatureCT(target_well)
                     add_cross_term!(model, ct, target = k, source = target_well, equation = :temperature_equation)
+                    ct = FacilityFromWellEnthalpyCT(target_well)
+                    add_cross_term!(model, ct, target = k, source = target_well, equation = :enthalpy_equation)
                 end
             end
         else

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -1108,6 +1108,7 @@ function setup_reservoir_simulator(case::JutulCase;
         tol_cnve_well = 10*tol_cnve,
         tol_eb_well = 1e4*tol_eb,
         inc_tol_dT = Inf,
+        tolerances = NamedTuple(),
         failure_cuts_timestep = true,
         max_timestep_cuts = 25,
         timesteps = :auto,
@@ -1233,7 +1234,7 @@ function setup_reservoir_simulator(case::JutulCase;
         max_timestep_cuts = max_timestep_cuts,
         kwarg...
     )
-    set_default_cnv_mb!(cfg, sim,
+    set_default_cnv_mb!(cfg, sim;
         tol_cnv = tol_cnv,
         tol_mb = tol_mb,
         tol_cnv_well = tol_cnv_well,
@@ -1248,6 +1249,7 @@ function setup_reservoir_simulator(case::JutulCase;
         tol_cnve_well = tol_cnve_well,
         tol_eb_well = tol_eb_well,
         inc_tol_dT = inc_tol_dT,
+        tolerances...,
     )
     return (sim, cfg)
 end

--- a/test/sens_forces.jl
+++ b/test/sens_forces.jl
@@ -133,6 +133,45 @@ end
 
     bc_explicit = FlowBoundaryCondition(1, 1.0e5, 300.0; enthalpy = 2.5e6)
     @test JutulDarcy.bc_inflow_enthalpy(bc_explicit, state_sat, 2) == 2.5e6
+
+    state_flux = (
+        Pressure = [10001.0, 10002.0, 10003.0],
+        Temperature = [300.0, 300.0, 300.0],
+        Saturations = [0.25 0.5 0.25; 0.75 0.5 0.75],
+        PhaseViscosities = [1.0 1.0 1.0; 1.0 1.0 1.0],
+        RelativePermeabilities = [1.0 1.0 1.0; 1.0 1.0 1.0],
+        PhaseMassDensities = [1.0 1.0 1.0; 1.0 1.0 1.0],
+        FluidEnthalpy = [10.0 20.0 30.0; 40.0 50.0 60.0],
+        FluidInternalEnergy = [9.0 9.0 9.0; 39.0 39.0 39.0],
+        TotalMasses = [1.0 1.0 1.0; 3.0 3.0 3.0]
+    )
+    gmap = Jutul.global_map(model)
+
+    bc_flux = FlowBoundaryCondition(3, 10005.0, 300.0;
+        density = 1.0,
+        enthalpy = 10.0,
+        fractional_flow = [0.25, 0.75],
+        trans_flow = 1.0,
+        trans_thermal = 0.0
+    )
+    qh_adv, qh_cond = JutulDarcy.compute_bc_heat_fluxes(sys, bc_flux, gmap, state_flux)
+    @test qh_cond == 0.0
+    @test qh_adv == -40.0
+
+    bc_flux_fallback = FlowBoundaryCondition(3, 10005.0, 300.0;
+        density = 1.0,
+        fractional_flow = [0.25, 0.75],
+        trans_flow = 1.0,
+        trans_thermal = 0.0
+    )
+    qh_adv_fallback, qh_cond_fallback = JutulDarcy.compute_bc_heat_fluxes(sys, bc_flux_fallback, gmap, state_flux)
+    @test qh_cond_fallback == 0.0
+    @test qh_adv_fallback == -210.0
+
+    state_flux_h = merge(state_flux, (Enthalpy = [700.0, 800.0, 900.0],))
+    qh_adv_state_h, qh_cond_state_h = JutulDarcy.compute_bc_heat_fluxes(sys, bc_flux_fallback, gmap, state_flux_h)
+    @test qh_cond_state_h == 0.0
+    @test qh_adv_state_h == -3600.0
 end
 
 @testset "bc and source force gradients" begin

--- a/test/sens_forces.jl
+++ b/test/sens_forces.jl
@@ -99,6 +99,42 @@ function numerical_diff_forces(model, state0, parameters, forces, tstep, G, eps 
     return dx
 end
 
+@testset "bc enthalpy handling" begin
+    G = get_1d_reservoir(3)
+    sys = ImmiscibleSystem((LiquidPhase(), VaporPhase()))
+    model = SimulationModel(G, sys)
+
+    bcs = [
+        FlowBoundaryCondition(3, 1.0e5, 300.0),
+        FlowBoundaryCondition(3, 1.0e5, 300.0; density = 1000.0),
+        FlowBoundaryCondition(3, 1.0e5, 300.0; enthalpy = 2.5e6),
+        FlowBoundaryCondition(3, 1.0e5, 300.0; fractional_flow = [1.0, 0.0], density = 1000.0, enthalpy = 2.5e6)
+    ]
+
+    for bc in bcs
+        forces = Dict(:bc => [bc])
+        x, cfg = Jutul.vectorize_forces(forces, model)
+        new_forces = Jutul.devectorize_forces(forces, model, x, cfg)
+        @test isequal(new_forces[:bc][1], bc)
+    end
+
+    bc = FlowBoundaryCondition(1, 1.0e5, 300.0)
+    state_sat = (
+        FluidEnthalpy = [1.0 10.0; 5.0 20.0],
+        Saturations = [0.2 0.3; 0.8 0.7]
+    )
+    @test JutulDarcy.bc_inflow_enthalpy(bc, state_sat, 2) == 17.0
+
+    state_h = (
+        Enthalpy = [11.0, 12.0],
+        FluidEnthalpy = [1.0 10.0; 5.0 20.0]
+    )
+    @test JutulDarcy.bc_inflow_enthalpy(bc, state_h, 2) == 12.0
+
+    bc_explicit = FlowBoundaryCondition(1, 1.0e5, 300.0; enthalpy = 2.5e6)
+    @test JutulDarcy.bc_inflow_enthalpy(bc_explicit, state_sat, 2) == 2.5e6
+end
+
 @testset "bc and source force gradients" begin
     model, state0, parameters, forces, tstep = setup_bl_twoforces(nc = 10, nstep = 10)
     test_force_vectorization(forces, tstep, model)


### PR DESCRIPTION
This pull request introduces support for enthalpy formulation of the thermal energy equation. This also includes extending cross-term calculations for geothermal wells, and adding enthalpy to boundary conditions.

**Facility Model: Surface Enthalpy Support**
- Added `SurfaceEnthalpy` variable and `SurfaceEnthalpyEquation` for tracking and constraining surface enthalpy in wells, including associated entity logic, equation updates, and relative/absolute increment limits. [[1]](diffhunk://#diff-f22a94a095e6a4ceddd1e738b79dc23c07c58b83b3177bc71bab52485f04f32eR149-R165) [[2]](diffhunk://#diff-f22a94a095e6a4ceddd1e738b79dc23c07c58b83b3177bc71bab52485f04f32eR872-R877) [[3]](diffhunk://#diff-a3ba60423e61c3e0eccc4bc7f0a172defd75e320d4b802aa6baf6c4aa08d40a1R17-R20) [[4]](diffhunk://#diff-a3ba60423e61c3e0eccc4bc7f0a172defd75e320d4b802aa6baf6c4aa08d40a1L135-R155)
- Introduced `FacilityFromWellEnthalpyCT` cross-term to link well enthalpy to facility equations, and refactored enthalpy extraction logic for wells. [[1]](diffhunk://#diff-31312c8689e16b68aa8af440f995e5a070f6e07b420461bc94ab3a34ad78f3b9L338-R368) [[2]](diffhunk://#diff-31312c8689e16b68aa8af440f995e5a070f6e07b420461bc94ab3a34ad78f3b9R396-R412) [[3]](diffhunk://#diff-31312c8689e16b68aa8af440f995e5a070f6e07b420461bc94ab3a34ad78f3b9L400-R438) [[4]](diffhunk://#diff-31312c8689e16b68aa8af440f995e5a070f6e07b420461bc94ab3a34ad78f3b9R459-R476)

**Geothermal Well Cross-Terms Refactoring**
- Refactored `btes_supply_return_massflux` and `btes_supply_return_heatflux` to handle both standard and compositional systems, support vectorized outputs, and ensure correct enthalpy calculations. [[1]](diffhunk://#diff-fda647906433ca0faee569877e1e72139c49e6efbda37524dda9cf4c4adb0102L64-R54) [[2]](diffhunk://#diff-fda647906433ca0faee569877e1e72139c49e6efbda37524dda9cf4c4adb0102L85-R182)

**Boundary Condition Enhancements**
- Extended the flow boundary condition API to support specifying enthalpy directly, with validation and propagation through constructors and helper functions. [[1]](diffhunk://#diff-1e39dc100e1d96fd4e4bdf1b0a1e4ce7eb80acea39e4cb9a3835f698cf4865ddR20-R27) [[2]](diffhunk://#diff-1e39dc100e1d96fd4e4bdf1b0a1e4ce7eb80acea39e4cb9a3835f698cf4865ddL38-R39) [[3]](diffhunk://#diff-1e39dc100e1d96fd4e4bdf1b0a1e4ce7eb80acea39e4cb9a3835f698cf4865ddL100-R126)