### PR TITLE
Use normalized saturation in brooks_corey_pc

### DIFF
--- a/src/variables/capillary.jl
+++ b/src/variables/capillary.jl
@@ -254,5 +254,5 @@ end
 
 function brooks_corey_pc(s, p_e, n, residual, residual_total, p_max = Inf)
     s_norm = normalized_saturation(s, residual, residual_total)
-    return min(p_e*s^(-1.0/n), p_max)
+    return min(p_e*s_norm^(-1.0/n), p_max)
 end


### PR DESCRIPTION
s_norm was computed but not used, so residual and residual_total were silently ignored and pc was evaluated on raw saturation.

Fixes #001