### PR TITLE
Fix `co2_density = :nist` being overridden by RK in `replace_co2_brine_properties!`

### DIFF
--- a/src/CO2Properties/setup.jl
+++ b/src/CO2Properties/setup.jl
@@ -120,7 +120,6 @@ function replace_co2_brine_properties!(dens, visc, K, salt_mole_fractions, salt_
                 v_co2 = dens.F[i, j][2]
                 dens.F[i, j] = pair_type(dens_calc[1], v_co2)
             end
-            dens.F[i, j] = props[:density]
             visc.F[i, j] = props[:viscosity]
             K.F[i, j] = props[:K]
         end


### PR DESCRIPTION
The if/else on `replace_co2` selects between the RK-computed CO2 density and the tabulated (NIST) value, but the line right after it unconditionally assigns `props[:density]`, so `:nist` always behaved as `:rk`. This deletes the stray line; the `:rk` branch is unaffected (it already assigns the same value). Fixes #263. 
Verified at 150 bar / 60 °C with 0.0177 NaCl mole fraction: before, both options returned 590.45 kg/m³; after, `:nist` returns the tabulated 603.82 kg/m³ and `:rk` is unchanged.